### PR TITLE
docs(scale): phase 3 slice D capacity alarms + canary rollback runbook

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,1 +1,2 @@
 2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice C guardrails doc (topic partitioning, connection/stale cleanup limits, saturation fallback, 32k-safe implementation handoff) and updated scale-slice tracker | branch feature/phase3-slicec-fanout-guardrails pushed
+2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice D capacity alert thresholds + canary/rollback runbook and updated scale-slice tracker | branch feature/phase3-sliced-capacity-canary ready

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,1 @@
+2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice C guardrails doc (topic partitioning, connection/stale cleanup limits, saturation fallback, 32k-safe implementation handoff) and updated scale-slice tracker | branch feature/phase3-slicec-fanout-guardrails pushed

--- a/docs/phase-3-capacity-alarms-canary.md
+++ b/docs/phase-3-capacity-alarms-canary.md
@@ -1,0 +1,89 @@
+# Phase 3 Slice D — Capacity Alarms + Canary Rollout (Issue #4)
+
+This slice turns Phase 3 guardrails into concrete rollout gates and rollback rules so scale changes can be shipped safely.
+
+## 1) Capacity alarm thresholds
+
+### Ingestion lane
+- **Queue depth warning:** > 500 jobs for 5 minutes.
+- **Queue depth critical:** > 1,500 jobs for 3 minutes.
+- **Oldest job age warning:** > 120 seconds for 5 minutes.
+- **Oldest job age critical:** > 300 seconds for 3 minutes.
+- **Retry ratio warning:** retries > 8% of jobs for 10 minutes.
+- **Retry ratio critical:** retries > 15% for 5 minutes.
+
+### Realtime lane
+- **Fanout p95 warning:** > 2.0s for 5 minutes.
+- **Fanout p95 critical:** > 2.5s for 3 minutes.
+- **Subscriber queue saturation warning:** > 60% queue fill on 10%+ subscribers for 5 minutes.
+- **Subscriber queue saturation critical:** > 80% queue fill on 15%+ subscribers for 3 minutes.
+- **Connection churn warning:** > 12%/min for 10 minutes.
+- **Connection churn critical:** > 20%/min for 5 minutes.
+
+### Infra lane
+- **Ingestor CPU critical:** > 85% for 10 minutes.
+- **Ingestor memory critical:** > 80% for 10 minutes.
+- **DB connection saturation warning:** > 70% pool utilization for 10 minutes.
+- **DB connection saturation critical:** > 85% for 5 minutes.
+
+## 2) Alert routing
+- Warnings route to `#trackflights-ops`.
+- Critical alerts page the on-call owner.
+- Auto-create incident issue when a critical alert lasts > 10 minutes.
+
+## 3) Canary rollout plan (10% → 50% → 100%)
+
+### Stage 0 — Preflight (required)
+- Schema migrations applied and verified.
+- Feature flag defaults to OFF.
+- Dashboards for queue depth, oldest age, fanout p95, and churn are live.
+- Rollback artifact/version is available and tested in staging.
+
+### Stage 1 — 10% canary (30 minutes)
+- Enable feature flag for 10% of airports (or hash bucket).
+- Success gates:
+  - No critical alerts.
+  - Fanout p95 < 2.0s.
+  - Queue oldest age < 120s.
+- If gates pass for full window, proceed to Stage 2.
+
+### Stage 2 — 50% canary (60 minutes)
+- Expand to 50% traffic.
+- Success gates:
+  - Retry ratio < 8%.
+  - Subscriber queue saturation below warning threshold.
+  - No sustained DB connection warning > 10 minutes.
+- If gates pass for full window, proceed to Stage 3.
+
+### Stage 3 — 100% rollout (120 minutes observation)
+- Expand to full traffic.
+- Maintain elevated alerting for 2 hours.
+- Exit criteria:
+  - No critical alarms.
+  - Warning alarms self-resolve within 10 minutes.
+
+## 4) Hard rollback triggers
+Rollback immediately to prior stable version if any are true:
+- Critical fanout latency (>2.5s) sustained for 5+ minutes.
+- Queue oldest age > 300s sustained for 5+ minutes.
+- Error budget burn rate > 2x target for 15+ minutes.
+- Crash/restart loop on ingestor (>= 3 restarts in 10 minutes).
+
+## 5) Rollback checklist
+1. Disable feature flag globally.
+2. Shift traffic to previous stable container revision.
+3. Drain/hold non-critical ingestion jobs (alerts/status updates continue).
+4. Confirm recovery of fanout latency and queue age to baseline.
+5. Publish incident summary + follow-up issue with timeline and metrics.
+
+## 6) 32k-safe implementation slices for local lane
+- **D1 Metrics plumbing:** emit queue age/depth, retry ratio, fanout p95, churn.
+- **D2 Alert rules:** codify warning/critical thresholds in monitoring config.
+- **D3 Canary controls:** flag rollout script + staged gate checks.
+- **D4 Rollback automation:** one-command rollback + post-rollback validation script.
+
+## 7) Acceptance criteria
+- Thresholds committed and visible in docs/config.
+- Canary stages have explicit pass/fail gates.
+- Rollback triggers are objective and actionable.
+- On-call can execute rollback in < 10 minutes with documented steps.

--- a/docs/phase-3-realtime-fanout-guardrails.md
+++ b/docs/phase-3-realtime-fanout-guardrails.md
@@ -1,0 +1,44 @@
+# Phase 3 Slice C — Realtime Fanout Guardrails (Issue #4)
+
+This slice defines guardrails for websocket/SSE fanout so ingestion spikes do not cascade into client latency, dropped updates, or runaway memory growth.
+
+## 1) Channel/topic partitioning policy
+- Primary partition key: `airport_code` (fallback region if airport missing).
+- Secondary partition key: `event_type` (`arrival`, `departure`, `status-change`, `alert`).
+- Optional tertiary high-load bucket: 15-minute rounded time bucket.
+- Producer route: `flights.{airport_code}.{event_type}`.
+- Production wildcard subscriptions are disabled.
+
+## 2) Connection + stale subscriber limits
+- Max concurrent realtime connections/node: **2,000**.
+- Max subscriptions/connection: **25**.
+- Max queued messages/subscriber: **200**.
+- Heartbeat interval: **30s**; stale mark at **90s**; forced terminate at **120s**.
+- Reconnect storm backoff: 1s → 2s → 4s, cap 30s.
+
+## 3) Saturation fallback behavior
+When saturation is detected:
+1. **Compaction mode**: latest-state only per flight id (3-5s cadence).
+2. **Priority mode**: preserve `alert` + `status-change`, defer low-priority telemetry.
+3. **Snapshot fallback**: poll snapshot endpoint every 15-30s until recovery.
+
+Recover only after 10 minutes below saturation thresholds.
+
+## 4) Trigger thresholds (feeds Slice D alarms)
+- Fanout delivery p95 > **2.5s** for 5 min.
+- Subscriber queue saturation (>80%) on >15% active subscribers for 3 min.
+- Connection churn > **20%/min** for 5 min.
+- Topic skew: top topic >35% fanout CPU for 10 min.
+
+## 5) 32k-safe implementation handoff slices
+- **C1 Topic routing contract**: typed topic builder + tests + wildcard guard.
+- **C2 Connection quota/cleanup**: per-node caps + heartbeat stale eviction.
+- **C3 Backpressure/degraded mode**: queue-depth fallback + priority routing.
+- **C4 Metrics/canary guard**: fanout metrics + staged canary (10%→50%→100%).
+
+## 6) Acceptance criteria
+- No wildcard realtime subscriptions in production.
+- Stale connections evicted within 120s.
+- Under synthetic load, p95 fanout latency <2.5s in normal mode.
+- Degraded mode preserves critical alert/status delivery under overload.
+- Metrics exported for Slice D capacity alarms/canary gates.

--- a/docs/phase-3-scale-slices.md
+++ b/docs/phase-3-scale-slices.md
@@ -1,0 +1,35 @@
+# Phase 3 — Scale Path for Ingestion + Realtime (Issue #4)
+
+Goal: increase ingestion and realtime capacity without destabilizing reliability controls.
+
+## Slice plan (32k-safe)
+
+### Slice A — Ingestion throughput profiling baseline
+Status: completed in prior cycle (baseline profiling/decomposition delivered).
+
+### Slice B — Queue/backpressure strategy ✅
+Status: completed in prior cycle.
+
+Deliverable:
+- `docs/phase-3-queue-retry-idempotency.md`
+
+### Slice C — Realtime fanout guardrails ✅
+Status: completed in this cycle.
+
+Deliverable:
+- `docs/phase-3-realtime-fanout-guardrails.md`
+
+### Slice D — Capacity alarms + canary rollout
+Deliverables:
+- Capacity alert thresholds (queue depth, cycle lag, fanout delay)
+- Canary rollout checklist + rollback triggers
+
+## Execution order
+1. Slice A (measure before changing behavior)
+2. Slice B (ingestion stability)
+3. Slice C (realtime stability)
+4. Slice D (safe rollout + alerting)
+
+## Current cycle action
+- Delivered: Slice C realtime fanout guardrails and local implementation handoff.
+- Next: Slice D capacity alarm thresholds + canary rollout checklist/rollback triggers.

--- a/docs/phase-3-scale-slices.md
+++ b/docs/phase-3-scale-slices.md
@@ -31,5 +31,5 @@ Deliverables:
 4. Slice D (safe rollout + alerting)
 
 ## Current cycle action
-- Delivered: Slice C realtime fanout guardrails and local implementation handoff.
-- Next: Slice D capacity alarm thresholds + canary rollout checklist/rollback triggers.
+- Delivered: Slice D capacity alarm thresholds and canary/rollback runbook.
+- Next: open PR for Slice C + D package, then execute D1 metrics plumbing implementation.


### PR DESCRIPTION
## Summary\n- add Phase 3 Slice D doc with concrete capacity alert thresholds for ingestion/realtime/infra\n- define staged canary rollout gates (10% -> 50% -> 100%)\n- add hard rollback triggers and rollback checklist\n- update scale slice tracker + STATUS.md\n\n## Context\n- advances #4 decomposition-first plan\n- follows Slice C guardrails with rollout safety gates\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Phase 3 scaling documentation outlining capacity alarm thresholds and canary rollout procedures with rollback triggers
  * Documented realtime fanout guardrail strategy including connection limits, saturation handling, and recovery mechanisms
  * Completed Phase 3 scale path documentation for ingestion and realtime system improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->