### PR TITLE
Phase 3 Slice D1: capacity metrics plumbing for ingestor

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,1 @@
+2026-03-29 | Rico | Issue #4 | Implemented Phase 3 Slice D1 capacity metrics plumbing (snapshot builder, threshold evaluator, poller wiring, docs) | branch feature/phase3-sliced-metrics-plumbing pushed

--- a/apps/ingestor/src/config.py
+++ b/apps/ingestor/src/config.py
@@ -27,6 +27,13 @@ class Settings(BaseSettings):
     predictions_enabled: bool = True
     anomaly_detection_enabled: bool = True
 
+    # Capacity alerting thresholds (Phase 3 Slice D1)
+    capacity_cycle_lag_warn_seconds: float = 15.0
+    capacity_queue_depth_warn: int = 2000
+    capacity_retry_ratio_warn: float = 0.2
+    capacity_fanout_p95_warn_ms: int = 1500
+    capacity_churn_ratio_warn: float = 0.35
+
     # Logging
     log_level: str = "INFO"
 

--- a/apps/ingestor/src/worker/capacity.py
+++ b/apps/ingestor/src/worker/capacity.py
@@ -1,0 +1,56 @@
+"""Capacity metrics helpers for poll-cycle observability and alerting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CapacitySnapshot:
+    cycle_duration_seconds: float
+    cycle_lag_seconds: float
+    queue_depth: int
+    retry_ratio: float
+    fanout_p95_ms: int
+    churn_ratio: float
+
+
+@dataclass(frozen=True)
+class CapacityThresholds:
+    cycle_lag_warn_seconds: float
+    queue_depth_warn: int
+    retry_ratio_warn: float
+    fanout_p95_warn_ms: int
+    churn_ratio_warn: float
+
+
+def build_capacity_snapshot(stats: dict[str, int], cycle_duration_seconds: float, poll_interval_seconds: int) -> CapacitySnapshot:
+    """Build a normalized capacity snapshot from poll stats.
+
+    Stats keys are optional to allow gradual rollout while queue/fanout metrics
+    are phased in.
+    """
+    normalized = max(1, int(stats.get("normalized", 0)))
+    churn_count = int(stats.get("new", 0)) + int(stats.get("updated", 0)) + int(stats.get("removed_from_api", 0))
+    retries = int(stats.get("retries", 0))
+    processed_jobs = max(1, int(stats.get("processed_jobs", normalized)))
+
+    return CapacitySnapshot(
+        cycle_duration_seconds=round(cycle_duration_seconds, 3),
+        cycle_lag_seconds=round(max(0.0, cycle_duration_seconds - poll_interval_seconds), 3),
+        queue_depth=int(stats.get("queue_depth", 0)),
+        retry_ratio=round(retries / processed_jobs, 4),
+        fanout_p95_ms=int(stats.get("fanout_p95_ms", 0)),
+        churn_ratio=round(churn_count / normalized, 4),
+    )
+
+
+def evaluate_capacity(snapshot: CapacitySnapshot, thresholds: CapacityThresholds) -> dict[str, bool]:
+    """Return per-signal breach map for alert routing."""
+    return {
+        "cycle_lag": snapshot.cycle_lag_seconds >= thresholds.cycle_lag_warn_seconds,
+        "queue_depth": snapshot.queue_depth >= thresholds.queue_depth_warn,
+        "retry_ratio": snapshot.retry_ratio >= thresholds.retry_ratio_warn,
+        "fanout_p95": snapshot.fanout_p95_ms >= thresholds.fanout_p95_warn_ms,
+        "churn_ratio": snapshot.churn_ratio >= thresholds.churn_ratio_warn,
+    }

--- a/apps/ingestor/src/worker/poller.py
+++ b/apps/ingestor/src/worker/poller.py
@@ -1,6 +1,7 @@
 """Polling worker — orchestrates flight ingestion, weather, predictions, and anomaly detection."""
 
 import time
+from dataclasses import asdict
 
 import structlog
 from supabase import create_client
@@ -10,6 +11,11 @@ from src.providers.base_provider import BaseFlightProvider
 from src.services.supabase_client import SupabaseFlightClient
 from src.services.flight_normalizer import normalize_batch
 from src.services.flight_diff_engine import compute_diff
+from src.worker.capacity import (
+    CapacityThresholds,
+    build_capacity_snapshot,
+    evaluate_capacity,
+)
 
 logger = structlog.get_logger()
 
@@ -46,6 +52,13 @@ class Poller:
             settings.supabase_url,
             settings.supabase_service_role_key,
         )
+        self._capacity_thresholds = CapacityThresholds(
+            cycle_lag_warn_seconds=settings.capacity_cycle_lag_warn_seconds,
+            queue_depth_warn=settings.capacity_queue_depth_warn,
+            retry_ratio_warn=settings.capacity_retry_ratio_warn,
+            fanout_p95_warn_ms=settings.capacity_fanout_p95_warn_ms,
+            churn_ratio_warn=settings.capacity_churn_ratio_warn,
+        )
 
     def _get_weather_ingester(self):
         if self._weather_ingester is None:
@@ -79,6 +92,7 @@ class Poller:
             cycle=self._cycle_count,
             provider=self.provider.name,
         )
+        cycle_started = time.monotonic()
 
         # ── 1-6. Flight ingestion ────────────────────────────────────
         flight_stats = await self._ingest_flights(airport)
@@ -101,8 +115,24 @@ class Poller:
             self._run_anomaly_detection(current_flights, weather_data, stats)
 
         # ── 10. Log ──────────────────────────────────────────────────
+        cycle_duration_seconds = time.monotonic() - cycle_started
+        capacity_snapshot = build_capacity_snapshot(
+            stats,
+            cycle_duration_seconds=cycle_duration_seconds,
+            poll_interval_seconds=settings.poll_interval_seconds,
+        )
+        breaches = evaluate_capacity(capacity_snapshot, self._capacity_thresholds)
+        stats.update(asdict(capacity_snapshot))
+
         db_stats = self.db.get_flight_stats()
         logger.info("Poll cycle complete", **stats, db_status_counts=db_stats)
+
+        if any(breaches.values()):
+            logger.warning(
+                "Capacity threshold exceeded",
+                breaches=[name for name, tripped in breaches.items() if tripped],
+                **asdict(capacity_snapshot),
+            )
 
         return stats
 

--- a/apps/ingestor/tests/test_capacity.py
+++ b/apps/ingestor/tests/test_capacity.py
@@ -1,0 +1,56 @@
+from src.worker.capacity import CapacityThresholds, build_capacity_snapshot, evaluate_capacity
+
+
+def test_build_capacity_snapshot_defaults_missing_optional_keys() -> None:
+    snapshot = build_capacity_snapshot(
+        {
+            "normalized": 10,
+            "new": 2,
+            "updated": 1,
+            "removed_from_api": 1,
+        },
+        cycle_duration_seconds=63.2,
+        poll_interval_seconds=60,
+    )
+
+    assert snapshot.cycle_lag_seconds == 3.2
+    assert snapshot.queue_depth == 0
+    assert snapshot.retry_ratio == 0.0
+    assert snapshot.fanout_p95_ms == 0
+    assert snapshot.churn_ratio == 0.4
+
+
+def test_evaluate_capacity_breaches() -> None:
+    snapshot = build_capacity_snapshot(
+        {
+            "normalized": 20,
+            "new": 3,
+            "updated": 3,
+            "removed_from_api": 2,
+            "queue_depth": 2500,
+            "retries": 12,
+            "processed_jobs": 40,
+            "fanout_p95_ms": 2200,
+        },
+        cycle_duration_seconds=95,
+        poll_interval_seconds=60,
+    )
+
+    breaches = evaluate_capacity(
+        snapshot,
+        CapacityThresholds(
+            cycle_lag_warn_seconds=15,
+            queue_depth_warn=2000,
+            retry_ratio_warn=0.2,
+            fanout_p95_warn_ms=1500,
+            churn_ratio_warn=0.3,
+        ),
+    )
+
+    assert breaches == {
+        "cycle_lag": True,
+        "queue_depth": True,
+        "retry_ratio": True,
+        "fanout_p95": True,
+        "churn_ratio": True,
+    }

--- a/docs/phase-3-capacity-metrics-plumbing.md
+++ b/docs/phase-3-capacity-metrics-plumbing.md
@@ -1,0 +1,35 @@
+# Phase 3 Slice D1 — Capacity Metrics Plumbing (Issue #4)
+
+This slice wires capacity signals into the ingestor cycle so alerting can trip on hard thresholds before user-visible degradation.
+
+## Added signals
+
+Per poll cycle (`apps/ingestor/src/worker/poller.py`):
+
+- `cycle_duration_seconds`
+- `cycle_lag_seconds` (`max(0, cycle_duration - poll_interval)`)
+- `queue_depth` (optional producer/consumer backlog key)
+- `retry_ratio` (`retries / processed_jobs`)
+- `fanout_p95_ms` (optional realtime signal)
+- `churn_ratio` (`(new + updated + removed_from_api) / normalized`)
+
+## Thresholds (env-configurable via settings)
+
+- `capacity_cycle_lag_warn_seconds` (default `15.0`)
+- `capacity_queue_depth_warn` (default `2000`)
+- `capacity_retry_ratio_warn` (default `0.2`)
+- `capacity_fanout_p95_warn_ms` (default `1500`)
+- `capacity_churn_ratio_warn` (default `0.35`)
+
+## Alert behavior
+
+If any threshold breaches in a cycle, ingestor emits:
+
+- `logger.warning("Capacity threshold exceeded", breaches=[...], ...)`
+
+This is intentionally log-first so downstream alert transports can be layered without changing core ingestion flow.
+
+## Follow-up slices
+
+- D2: persist capacity snapshots in Supabase for dashboard trend lines
+- D3: wire warning logs to pager/notification policy

--- a/docs/phase-3-scale-slices.md
+++ b/docs/phase-3-scale-slices.md
@@ -1,0 +1,34 @@
+# Phase 3 — Scale Path for Ingestion + Realtime (Issue #4)
+
+Goal: increase ingestion and realtime capacity without destabilizing reliability controls.
+
+## Slice plan (32k-safe)
+
+### Slice A — Ingestion throughput profiling baseline ✅
+Status: completed in prior cycle (baseline profiling and decomposition delivered).
+
+### Slice B — Queue/backpressure strategy ✅
+Deliverable:
+- `docs/phase-3-queue-retry-idempotency.md`
+
+### Slice C — Realtime fanout guardrails ✅
+Deliverables:
+- Channel/topic partitioning policy
+- Connection limits and stale-subscriber cleanup policy
+- Saturation fallback behavior
+
+### Slice D — Capacity alarms + canary rollout (in progress)
+Deliverables:
+- Capacity alert thresholds (queue depth, cycle lag, fanout delay)
+- Canary rollout checklist + rollback triggers
+- D1 metrics plumbing implementation (`apps/ingestor/src/worker/capacity.py`) ✅
+
+## Execution order
+1. Slice A (measure before changing behavior)
+2. Slice B (ingestion stability)
+3. Slice C (realtime stability)
+4. Slice D (safe rollout + alerting)
+
+## Current cycle action
+- Delivered: Slice D1 metrics plumbing + threshold evaluator + unit tests.
+- Next: D2 persist snapshots to Supabase for trend dashboarding.


### PR DESCRIPTION
## Summary
- add `worker/capacity.py` to compute normalized per-cycle capacity signals (lag, depth, retries, fanout p95, churn)
- wire `Poller.execute()` to emit capacity snapshots and warning logs when thresholds breach
- add configurable threshold settings in `src/config.py`
- add unit tests for snapshot + breach evaluation and docs for Slice D1 rollout

## Why
Issue #4 requires concrete scale-path controls. This lands the D1 implementation slice so warning signals are available before user-facing degradation.

## Validation
- Test execution blocked in this runtime (`python3 -m pytest` unavailable: `No module named pytest`)
- Added focused unit tests in `apps/ingestor/tests/test_capacity.py` for CI execution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated capacity metrics monitoring into the ingestion polling cycle with automatic threshold-based alerting for cycle lag, queue depth, retry ratio, fanout latency, and churn metrics.
  * Added configurable warning thresholds (via environment variables) to detect and log capacity breaches.

* **Documentation**
  * Added guides for Phase 3 capacity metrics architecture and Phase 3 scaling roadmap with planned enhancements.

* **Tests**
  * Added test coverage for capacity metrics calculation and threshold evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->