### PR TITLE
Phase 3 Slice C/D: realtime guardrails + capacity canary rollout docs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,2 @@
+2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice B docs (`docs/phase-3-queue-retry-idempotency.md`, `docs/phase-3-scale-slices.md`) with queue/backpressure, retry, idempotency, and failure-mode response policy | branch feature/phase3-sliceb-queue-retry-idempotency pushed (commit 7a53265)
+2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice C docs (`docs/phase-3-realtime-fanout-guardrails.md`) and refreshed `docs/phase-3-scale-slices.md` with next D-slice rollout plan | branch feature/phase3-slicec-realtime-guardrails ready

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,2 +1,3 @@
 2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice B docs (`docs/phase-3-queue-retry-idempotency.md`, `docs/phase-3-scale-slices.md`) with queue/backpressure, retry, idempotency, and failure-mode response policy | branch feature/phase3-sliceb-queue-retry-idempotency pushed (commit 7a53265)
 2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice C docs (`docs/phase-3-realtime-fanout-guardrails.md`) and refreshed `docs/phase-3-scale-slices.md` with next D-slice rollout plan | branch feature/phase3-slicec-realtime-guardrails ready
+2026-03-29 | Rico | Issue #4 | Added Phase 3 Slice D runbook (`docs/phase-3-capacity-canary-rollout.md`) with concrete thresholds, canary gates, rollback triggers, and implementation handoff | branch feature/phase3-slicec-realtime-guardrails updated

--- a/docs/phase-3-capacity-canary-rollout.md
+++ b/docs/phase-3-capacity-canary-rollout.md
@@ -1,0 +1,105 @@
+# Phase 3 Slice D — Capacity Alarms + Canary Rollout (Issue #4)
+
+This slice defines concrete alert thresholds and a low-risk rollout/rollback process for ingestion + realtime changes.
+
+## 1) Alert thresholds (initial)
+
+Use a 3-level model:
+- **Info**: early signal, no paging.
+- **Warn**: action required in business hours.
+- **Critical**: page + automated mitigation.
+
+### Ingestion queue health
+
+- **Queue depth (`ingest_queue_depth`)**
+  - Info: > 500 for 5m
+  - Warn: > 2,000 for 10m
+  - Critical: > 5,000 for 10m
+
+- **Oldest job age (`ingest_oldest_job_age_sec`)**
+  - Info: > 60s for 5m
+  - Warn: > 180s for 10m
+  - Critical: > 300s for 10m
+
+- **Retry rate (`ingest_retry_rate`)**
+  - Warn: > 5% for 15m
+  - Critical: > 10% for 10m
+
+### Pipeline cycle lag
+
+- **Scheduler/cycle lag (`pipeline_cycle_lag_sec`)**
+  - Info: > 30s for 5m
+  - Warn: > 90s for 10m
+  - Critical: > 180s for 10m
+
+### Realtime fanout health
+
+- **Fanout p95 delay (`realtime_fanout_delay_p95_ms`)**
+  - Info: > 800ms for 5m
+  - Warn: > 1,500ms for 10m
+  - Critical: > 3,000ms for 10m
+
+- **Dropped/bounced realtime messages (`realtime_drop_rate`)**
+  - Warn: > 1% for 10m
+  - Critical: > 3% for 10m
+
+- **Active subscribers per topic (`realtime_topic_subscribers`)**
+  - Warn: > 80% of cap for 10m
+  - Critical: > 95% of cap for 5m
+
+## 2) Alert actions and ownership
+
+- **Warn**
+  - Open incident note in ops channel.
+  - Check queue/fanout dashboard for hotspot topic or route.
+  - Apply scale-up runbook if sustained >15m.
+
+- **Critical**
+  - Page on-call.
+  - Trigger degrade mode (from Slice C):
+    - reduce low-priority fanout frequency
+    - enforce stricter stale-subscriber eviction
+    - temporarily cap new subscriber joins on saturated topics
+  - If no recovery in 15m, rollback canary.
+
+## 3) Canary rollout checklist
+
+### Pre-rollout gate (must pass)
+
+- [ ] CI green on feature branch
+- [ ] Required env vars confirmed for target environment
+- [ ] Dashboard panels visible for all metrics above
+- [ ] Alert rules loaded but critical auto-page muted for first 15m warm-up
+- [ ] Rollback command/script pre-validated
+
+### Rollout plan
+
+1. **Canary 10% traffic / 1 shard / 1 region** for 30 minutes.
+2. If no critical alerts and warn alerts stable/decreasing, move to **25% for 60 minutes**.
+3. Then **50% for 60 minutes**.
+4. Full rollout only if:
+   - no critical events
+   - warn alerts are acknowledged with known cause and no upward trend
+   - p95 fanout and queue age are below warn thresholds for 45 continuous minutes
+
+### Rollback triggers (immediate)
+
+Rollback immediately if any occur during canary:
+- Critical queue depth or oldest-job-age alert fires for >10m
+- Critical fanout delay alert fires for >10m
+- Drop rate critical threshold breached for >5m
+- User-visible stale-data incidents confirmed in production
+
+### Post-rollout validation (24h)
+
+- [ ] No repeating warn/critical alerts tied to rollout changes
+- [ ] Retry rate stayed below 5%
+- [ ] Fanout p95 trend within expected variance
+- [ ] Incident log updated with rollout result and next tuning actions
+
+## 4) Handoff items for implementation slice
+
+- Add metric emitters for missing queue-age/fanout-delay counters.
+- Add alert rule manifests for warn/critical thresholds.
+- Add rollout runbook script for canary percentage progression.
+- Add automated rollback shortcut in ops docs.

--- a/docs/phase-3-realtime-fanout-guardrails.md
+++ b/docs/phase-3-realtime-fanout-guardrails.md
@@ -1,0 +1,81 @@
+# Phase 3 Slice C — Realtime Fanout Guardrails
+
+Issue: `mendyraul/TrackFlights#4`
+
+## Why this slice exists
+As ingest volume grows, unmanaged realtime fanout can overload websocket channels, create reconnect storms, and cause stale subscribers to consume throughput. This slice defines explicit guardrails before broader rollout.
+
+## SLO targets
+- p95 realtime fanout delay: **< 2s** from DB write to client event
+- websocket disconnect rate: **< 2%** per 15-minute window
+- stale subscriber ratio: **< 10%** of active channel members
+
+## Channel partitioning policy
+Use bounded partitioned channels instead of one unbounded global channel.
+
+### Channel naming
+- `flights:airport:{iata}:p{partition}`
+- Partition count default: `4` per airport
+- Partition key: `flight_id % partition_count`
+
+### Rules
+1. Clients subscribe only to channels needed for current view scope.
+2. Server broadcast path computes partition once per event and emits only to that partition.
+3. Do not broadcast wildcard events to every partition.
+
+## Subscriber limits and cleanup
+### Hard caps
+- Soft warning: **150 subscribers/channel**
+- Hard cap: **200 subscribers/channel**
+
+### Cleanup cadence
+- Sweep interval: every **60s**
+- Disconnect subscribers idle for **> 120s** without heartbeat/ack
+- Track `last_seen_at` and `heartbeat_miss_count`
+
+### Degrade behavior at cap
+1. New subscriber receives `channel_saturated` status payload.
+2. Client falls back to polling (`30s` cadence) until channel pressure drops.
+3. UI shows degraded realtime badge (yellow).
+
+## Saturation fallback modes
+### Mode 0 — Normal
+- Full `INSERT/UPDATE/DELETE` fanout
+
+### Mode 1 — Elevated pressure (warning)
+Trigger: subscribers > 150 OR p95 fanout delay > 2s for 5m
+- Drop low-value transient fields from payload (`heading`, `vertical_speed_fpm`)
+- Keep status/position/time-critical fields
+
+### Mode 2 — Saturated (critical)
+Trigger: subscribers > 200 OR p95 fanout delay > 5s for 2m
+- Broadcast only status changes and major position deltas
+- Force noncritical clients to polling fallback
+- Emit operator alert and open incident checklist
+
+## Metrics + thresholds
+| Metric | Warning | Critical | Action |
+|---|---:|---:|---|
+| `realtime_channel_subscribers` | >150 | >200 | enter mode 1/2 |
+| `realtime_fanout_delay_p95_ms` | >2000 | >5000 | degrade payload and fallback |
+| `realtime_disconnect_rate` | >2% | >5% | trigger reconnect-throttle controls |
+| `realtime_stale_subscriber_ratio` | >10% | >20% | force cleanup sweep |
+
+## Rollout checklist (pre-D slice)
+- [ ] Add partition constants to config and environment matrix
+- [ ] Implement heartbeat tracking for subscriber lifecycle
+- [ ] Add dashboards for fanout delay and subscriber saturation
+- [ ] Add alert routes (warning -> Slack/Telegram, critical -> incident)
+- [ ] Run 30-minute canary at 10% traffic before global enablement
+
+## Ownership and runbook
+- Primary owner: Rico (orchestration)
+- Local implementation lane: Junior/Fix
+- Escalation to Codex: only after 2 failed local attempts on same implementation slice
+
+Incident first response:
+1. Confirm active mode (0/1/2)
+2. Validate cleanup worker is running
+3. Force mode 2 if delays exceed critical threshold
+4. Announce degrade state in ops channel
+5. Create follow-up issue with snapshots and timelines

--- a/docs/phase-3-scale-slices.md
+++ b/docs/phase-3-scale-slices.md
@@ -1,0 +1,38 @@
+# Phase 3 — Scale Path for Ingestion + Realtime (Issue #4)
+
+Goal: increase ingestion and realtime capacity without destabilizing reliability controls.
+
+## Slice plan (32k-safe)
+
+### Slice A — Ingestion throughput profiling baseline
+Status: completed in prior cycle.
+
+### Slice B — Queue/backpressure strategy
+Status: completed in prior cycle.
+
+### Slice C — Realtime fanout guardrails ✅
+Status: completed in this cycle.
+
+Deliverables:
+- Channel partitioning policy and naming convention
+- Subscriber caps and stale-connection cleanup
+- Saturation fallback behavior and degrade modes
+- Capacity thresholds tied to warning/critical runbook actions
+
+### Slice D — Capacity alarms + canary rollout
+Status: queued next.
+
+Deliverables:
+- Capacity alert thresholds (queue depth, cycle lag, fanout delay)
+- Canary rollout checklist + rollback triggers
+- Dashboard/ops visibility checklist for rollout windows
+
+## Execution order
+1. Slice A (measure before changing behavior)
+2. Slice B (ingestion stability)
+3. Slice C (realtime stability)
+4. Slice D (safe rollout + alerting)
+
+## Current cycle action
+- Delivered: Slice C realtime fanout guardrails + operational runbook (`docs/phase-3-realtime-fanout-guardrails.md`).
+- Next: Slice D canary rollout checklist and alerting thresholds.

--- a/docs/phase-3-scale-slices.md
+++ b/docs/phase-3-scale-slices.md
@@ -19,13 +19,14 @@ Deliverables:
 - Saturation fallback behavior and degrade modes
 - Capacity thresholds tied to warning/critical runbook actions
 
-### Slice D — Capacity alarms + canary rollout
-Status: queued next.
+### Slice D — Capacity alarms + canary rollout ✅
+Status: completed in this cycle.
 
 Deliverables:
 - Capacity alert thresholds (queue depth, cycle lag, fanout delay)
 - Canary rollout checklist + rollback triggers
 - Dashboard/ops visibility checklist for rollout windows
+- Delivered in `docs/phase-3-capacity-canary-rollout.md`
 
 ## Execution order
 1. Slice A (measure before changing behavior)
@@ -34,5 +35,5 @@ Deliverables:
 4. Slice D (safe rollout + alerting)
 
 ## Current cycle action
-- Delivered: Slice C realtime fanout guardrails + operational runbook (`docs/phase-3-realtime-fanout-guardrails.md`).
-- Next: Slice D canary rollout checklist and alerting thresholds.
+- Delivered: Slice D canary rollout + alert threshold runbook (`docs/phase-3-capacity-canary-rollout.md`).
+- Next: convert Slice D runbook into alert manifests/dashboard checks in implementation PR.


### PR DESCRIPTION
## Summary\n- add Phase 3 Slice C realtime fanout guardrails and failure-mode controls\n- add Phase 3 Slice D capacity/canary rollout runbook with thresholds and rollback triggers\n- update phase slice index and STATUS tracker for dispatch visibility\n\n## Context\nImplements decomposition-first work for #4 (Phase 3 scale path), focusing on docs/operational guardrails before deeper code slices.\n\n## Validation\n- docs-only change\n- cross-links verified in docs/phase-3-scale-slices.md\n\nCloses #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 3 Slice D: capacity canary rollout guide with alert thresholds, staged rollout plan (10%–100%), and post-rollout validation checklist.
  * Added Phase 3 Slice C: realtime fanout guardrails documentation including channel strategy, subscriber limits, and saturation handling modes.
  * Added Phase 3 scale path execution plan documenting the multi-slice delivery roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->