### PR TITLE
Stabilize health endpoints and add smoke check

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -28,3 +28,4 @@ YYYY-MM-DD | Agent | Issue #N | Summary | Status
 
 2026-03-28 | Rico | Issue #4 (Phase 3 Slice 3) | Added Supabase realtime throughput baseline assumptions + repeatable measurement recipe and evidence template; linked into production baseline docs | Completed on feature/phase1-ci-baseline
 2026-03-28 | Rico | Issue #8 (Phase 1 Slice A) | Replaced baseline CI with scoped PR/dev pipeline: change-detection + separate web lint/typecheck/build and ingestor pytest jobs with dependency caching and safe no-op path | Completed on feature/phase1-ci-baseline
+2026-04-07 | Rico | Issue #43 | Added stable /api/healthz/live + /api/healthz/ready routes and smoke-health script covering / + health endpoints | PR #44 open

--- a/apps/web/src/app/api/healthz/live/route.ts
+++ b/apps/web/src/app/api/healthz/live/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      check: 'live',
+      timestamp: new Date().toISOString()
+    },
+    { status: 200 }
+  );
+}

--- a/apps/web/src/app/api/healthz/ready/route.ts
+++ b/apps/web/src/app/api/healthz/ready/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+function hasRequiredEnv() {
+  const required = ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'];
+  const missing = required.filter((key) => !process.env[key]);
+
+  return {
+    missing,
+    ok: missing.length === 0
+  };
+}
+
+export async function GET() {
+  const env = hasRequiredEnv();
+
+  return NextResponse.json(
+    {
+      status: env.ok ? 'ready' : 'degraded',
+      check: 'ready',
+      timestamp: new Date().toISOString(),
+      missingEnv: env.missing
+    },
+    { status: env.ok ? 200 : 503 }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "security:baseline": "./scripts/security-baseline.sh",
     "ops:evidence-template": "./scripts/create-alert-evidence.sh",
     "ops:release-evidence": "./scripts/create-release-evidence.sh",
-    "ops:failover-drill": "./scripts/test-ingestor-failover.sh"
+    "ops:failover-drill": "./scripts/test-ingestor-failover.sh",
+    "smoke:health": "./scripts/smoke-health-endpoints.sh"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/smoke-health-endpoints.sh
+++ b/scripts/smoke-health-endpoints.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+
+declare -a ENDPOINTS=(
+  "/"
+  "/api/healthz/live"
+  "/api/healthz/ready"
+)
+
+for endpoint in "${ENDPOINTS[@]}"; do
+  code=$(curl -sS -o /tmp/trackflights-health.out -w "%{http_code}" "${BASE_URL}${endpoint}")
+  if [[ "$code" != "200" ]]; then
+    echo "FAIL ${endpoint} -> HTTP ${code}"
+    cat /tmp/trackflights-health.out
+    exit 1
+  fi
+  echo "OK ${endpoint} -> HTTP ${code}"
+done
+
+echo "Health smoke passed for ${BASE_URL}"


### PR DESCRIPTION
## Summary
- add app-router health endpoints at /api/healthz/live and /api/healthz/ready
- make readiness explicit (200 when required public Supabase envs exist, 503 otherwise)
- add scripts/smoke-health-endpoints.sh and npm run smoke:health to validate root + health endpoints

## Validation
- npm run build
- ./scripts/smoke-health-endpoints.sh http://localhost:3000

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced health-check endpoints to monitor application status and readiness, with live and ready state checks.

* **Chores**
  * Added a smoke-test script to verify health endpoint availability.
  * Updated status documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->