### PR TITLE
chore: add branch hygiene audit tooling and policy

### DIFF
--- a/.github/workflows/branch-hygiene.yml
+++ b/.github/workflows/branch-hygiene.yml
@@ -1,0 +1,44 @@
+name: Branch Hygiene
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Delete merged remote feature/* branches (dangerous)."
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+  schedule:
+    - cron: "0 13 * * 3"
+
+permissions:
+  contents: write
+
+jobs:
+  branch-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run branch hygiene (dry-run by default)
+        env:
+          APPLY: ${{ github.event.inputs.apply || 'false' }}
+        run: |
+          chmod +x scripts/git/branch-hygiene.sh
+          if [ "$APPLY" = "true" ]; then
+            scripts/git/branch-hygiene.sh --apply --remote origin --default-branch main | tee branch-hygiene-output.txt
+          else
+            scripts/git/branch-hygiene.sh --remote origin --default-branch main | tee branch-hygiene-output.txt
+          fi
+
+      - name: Upload run output
+        uses: actions/upload-artifact@v4
+        with:
+          name: branch-hygiene-output
+          path: branch-hygiene-output.txt

--- a/STATUS.md
+++ b/STATUS.md
@@ -29,3 +29,4 @@ YYYY-MM-DD | Agent | Issue #N | Summary | Status
 2026-03-28 | Rico | Issue #4 (Phase 3 Slice 3) | Added Supabase realtime throughput baseline assumptions + repeatable measurement recipe and evidence template; linked into production baseline docs | Completed on feature/phase1-ci-baseline
 2026-03-28 | Rico | Issue #8 (Phase 1 Slice A) | Replaced baseline CI with scoped PR/dev pipeline: change-detection + separate web lint/typecheck/build and ingestor pytest jobs with dependency caching and safe no-op path | Completed on feature/phase1-ci-baseline
 2026-04-08 | Rico | Issue #42 | Added weekly GitHub Actions branch-hygiene dry-run workflow with explicit manual apply gate + policy automation notes | Pushed to feature/issue-42-branch-hygiene-audit (PR #46)
+2026-04-08 | Rico | Issue #42 | Re-verified PR #46 merge health (CLEAN, all checks green) and posted issue progress handoff for merge/first scheduled evidence review | Awaiting merge/close sequencing

--- a/STATUS.md
+++ b/STATUS.md
@@ -28,3 +28,4 @@ YYYY-MM-DD | Agent | Issue #N | Summary | Status
 
 2026-03-28 | Rico | Issue #4 (Phase 3 Slice 3) | Added Supabase realtime throughput baseline assumptions + repeatable measurement recipe and evidence template; linked into production baseline docs | Completed on feature/phase1-ci-baseline
 2026-03-28 | Rico | Issue #8 (Phase 1 Slice A) | Replaced baseline CI with scoped PR/dev pipeline: change-detection + separate web lint/typecheck/build and ingestor pytest jobs with dependency caching and safe no-op path | Completed on feature/phase1-ci-baseline
+2026-04-08 | Rico | Issue #42 | Added weekly GitHub Actions branch-hygiene dry-run workflow with explicit manual apply gate + policy automation notes | Pushed to feature/issue-42-branch-hygiene-audit (PR #46)

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,3 +30,4 @@ YYYY-MM-DD | Agent | Issue #N | Summary | Status
 2026-03-28 | Rico | Issue #8 (Phase 1 Slice A) | Replaced baseline CI with scoped PR/dev pipeline: change-detection + separate web lint/typecheck/build and ingestor pytest jobs with dependency caching and safe no-op path | Completed on feature/phase1-ci-baseline
 2026-04-08 | Rico | Issue #42 | Added weekly GitHub Actions branch-hygiene dry-run workflow with explicit manual apply gate + policy automation notes | Pushed to feature/issue-42-branch-hygiene-audit (PR #46)
 2026-04-08 | Rico | Issue #42 | Re-verified PR #46 merge health (CLEAN, all checks green) and posted issue progress handoff for merge/first scheduled evidence review | Awaiting merge/close sequencing
+2026-04-08 | Rico | Issue #42 | Ran fresh branch audit, pruned stale local branch `feature/phase1-ci-baseline`, and added operations report under docs/operations. | Ready on feature/issue-42-branch-hygiene-audit

--- a/docs/branch-hygiene-2026-04-08.md
+++ b/docs/branch-hygiene-2026-04-08.md
@@ -1,0 +1,54 @@
+# Branch Hygiene Audit
+
+Generated: 2026-04-08 07:04:30 UTC
+
+Default branch: origin/main
+
+## Local branches (excluding main)
+feature/issue-40-schema-smoke|2026-04-08|mendyraul|feat(schema): add supabase schema smoke gate for issue 40
+feature/issue-42-branch-hygiene-audit|2026-03-30|Raul Mendy|Merge pull request #5 from mendyraul/feature/phase1-ci-baseline
+feature/issue-43-health-smoke|2026-04-07|mendyraul|docs: record issue 43 completion status
+feature/phase1-ci-baseline|2026-03-28|mendyraul|ci: add scoped web+ingestor workflow jobs
+feature/phase2-alert-baseline-checks|2026-03-29|mendyraul|fix(phase2): harden baseline evidence ingestor check
+feature/phase2-slicea-monitoring-alert-matrix|2026-03-29|mendyraul|docs: add phase2 sliceA monitoring alert matrix
+feature/phase2-sliceb-logging-standard|2026-03-30|mendyraul|docs: add phase2 structured logging + correlation id standard
+feature/phase2-sliceb-structured-logging|2026-03-29|mendyraul|docs(phase2): add structured logging checklist baseline
+feature/phase2-slicec-drill-evidence|2026-03-29|mendyraul|docs(reliability): record phase2 backup/restore drill evidence
+feature/phase2-slicec-health-runbook|2026-03-29|mendyraul|docs(reliability): add phase-2 health coverage and incident playbook
+feature/phase2-sliced-alert-evidence-proof|2026-03-29|mendyraul|docs: scaffold phase2 slice D evidence pack for alerts and backup drill
+feature/phase3-scale-sliceA|2026-03-29|mendyraul|docs(scale): decompose phase 3 into execution slices
+feature/phase3-sliceA-adr|2026-03-29|mendyraul|docs(scale): add phase-3 slice A risk matrix and ingestion topology ADR
+feature/phase3-sliceb-queue-retry-idempotency|2026-03-29|mendyraul|fix(web): prevent preview build crash when Supabase env vars are missing
+feature/phase3-slicec-fanout-guardrails|2026-03-29|mendyraul|docs(scale): add phase-3 realtime fanout guardrails
+feature/phase3-slicec-realtime-guardrails|2026-03-29|mendyraul|docs(trackflights): add phase 3 slice d capacity+canary runbook
+feature/phase3-sliced-capacity-canary|2026-03-29|mendyraul|docs(scale): add phase-3 slice D capacity alarms and canary runbook
+feature/phase3-sliced-metrics-plumbing|2026-03-29|mendyraul|feat(ingestor): add phase3 capacity metrics plumbing
+feature/phase4-release-runbook-issue21|2026-03-29|mendyraul|docs: add release checklist and rollback runbook (issue #21)
+feature/phase4-security-checklist-issue19|2026-03-29|mendyraul|docs(security): add phase4 hardening checklist baseline audit
+feature/phase4-security-release-slice1|2026-03-29|mendyraul|docs(phase4): add performance baseline protocol and gate linkage
+feature/phase4-slicec-preflight-runbook|2026-03-29|mendyraul|docs(release): add slice-c checklist, rollback runbook, and preflight script
+
+## Remote branches already merged into origin/main
+origin/HEAD -> origin/main
+
+## Remote branches NOT merged into origin/main
+origin/feature/issue-40-schema-smoke
+origin/feature/issue-43-health-smoke
+origin/feature/phase2-alert-baseline-checks
+origin/feature/phase2-slicea-monitoring-alert-matrix
+origin/feature/phase2-sliceb-logging-standard
+origin/feature/phase2-sliceb-structured-logging
+origin/feature/phase2-slicec-drill-evidence
+origin/feature/phase2-slicec-health-runbook
+origin/feature/phase2-sliced-alert-evidence-proof
+origin/feature/phase3-scale-sliceA
+origin/feature/phase3-sliceA-adr
+origin/feature/phase3-sliceb-queue-retry-idempotency
+origin/feature/phase3-slicec-fanout-guardrails
+origin/feature/phase3-slicec-realtime-guardrails
+origin/feature/phase3-sliced-capacity-canary
+origin/feature/phase3-sliced-metrics-plumbing
+origin/feature/phase4-release-runbook-issue21
+origin/feature/phase4-security-checklist-issue19
+origin/feature/phase4-security-release-slice1
+origin/feature/phase4-slicec-preflight-runbook

--- a/docs/branch-hygiene-policy.md
+++ b/docs/branch-hygiene-policy.md
@@ -1,0 +1,20 @@
+# Branch Hygiene Policy
+
+This repo follows a conservative cleanup workflow:
+
+1. Never push directly to `main`.
+2. Feature work happens on `feature/*` branches via PR.
+3. A branch is eligible for deletion only after:
+   - PR is merged, and
+   - branch appears in `git branch -r --merged origin/main`.
+4. Keep long-lived protected branches (`main`, `dev` if present).
+5. Run `scripts/git/branch-hygiene-audit.sh` before cleanup windows.
+
+## Safe cleanup commands (manual confirmation required)
+
+- Delete one merged remote branch:
+  - `git push origin --delete <branch>`
+- Delete local tracking branch:
+  - `git branch -d <branch>`
+
+Do not bulk-delete without verifying branch purpose and PR status.

--- a/docs/branch-hygiene-policy.md
+++ b/docs/branch-hygiene-policy.md
@@ -1,20 +1,23 @@
 # Branch Hygiene Policy
 
-This repo follows a conservative cleanup workflow:
+## Goals
+- Keep active work obvious.
+- Remove stale merged branches safely.
+- Never delete unmerged work without explicit human approval.
 
-1. Never push directly to `main`.
-2. Feature work happens on `feature/*` branches via PR.
-3. A branch is eligible for deletion only after:
-   - PR is merged, and
-   - branch appears in `git branch -r --merged origin/main`.
-4. Keep long-lived protected branches (`main`, `dev` if present).
-5. Run `scripts/git/branch-hygiene-audit.sh` before cleanup windows.
+## Protected Branches
+- `main`, `master`, `dev`, `develop`, `staging`, `release/*`
 
-## Safe cleanup commands (manual confirmation required)
+## Weekly Cadence
+1. Run inventory:
+   - `scripts/git/branch-hygiene-audit.sh main origin > docs/branch-hygiene-$(date +%F).md`
+2. Run cleanup dry-run for merged `feature/*` branches:
+   - `scripts/git/branch-hygiene.sh --remote origin --default-branch main`
+3. Review output and confirm no active branch is listed.
+4. Apply deletion only after confirmation:
+   - `scripts/git/branch-hygiene.sh --apply --remote origin --default-branch main`
 
-- Delete one merged remote branch:
-  - `git push origin --delete <branch>`
-- Delete local tracking branch:
-  - `git branch -d <branch>`
-
-Do not bulk-delete without verifying branch purpose and PR status.
+## Safety Rules
+- Default mode is dry-run.
+- Only merged `feature/*` branches are eligible for automated deletion.
+- Unmerged stale branches require manual triage and explicit approval.

--- a/docs/branch-hygiene-policy.md
+++ b/docs/branch-hygiene-policy.md
@@ -17,6 +17,11 @@
 4. Apply deletion only after confirmation:
    - `scripts/git/branch-hygiene.sh --apply --remote origin --default-branch main`
 
+### Automation
+- GitHub Actions workflow: `.github/workflows/branch-hygiene.yml`
+- Scheduled run: Wednesdays 09:00 ET (`0 13 * * 3`) in dry-run mode.
+- Manual runs support `apply=true`, but should only be used after explicit approval and audit review.
+
 ## Safety Rules
 - Default mode is dry-run.
 - Only merged `feature/*` branches are eligible for automated deletion.

--- a/docs/operations/branch-hygiene-2026-04-08.md
+++ b/docs/operations/branch-hygiene-2026-04-08.md
@@ -1,0 +1,22 @@
+# Branch Hygiene Audit — 2026-04-08
+
+## Scope
+Issue #42 (`Branch hygiene cleanup: inventory and prune stale feature branches`).
+
+## Snapshot
+- Audit time: 2026-04-08 13:04 EDT
+- Local branches scanned: 24
+- Stale local branches tracking deleted remotes (`: gone`): 1
+
+## Action taken
+Pruned stale local branch:
+- `feature/phase1-ci-baseline` (remote already gone)
+
+Command used:
+```bash
+git branch -D feature/phase1-ci-baseline
+```
+
+## Remaining branch posture
+- No local branches currently marked `: gone` after prune.
+- Next hygiene pass should focus on consolidating long-lived phase branches after their PR state is confirmed.

--- a/scripts/git/branch-hygiene-audit.sh
+++ b/scripts/git/branch-hygiene-audit.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+default_branch="${1:-main}"
+remote="${2:-origin}"
+
+printf "# Branch Hygiene Audit\n\n"
+printf "Generated: %s\n\n" "$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+printf "Default branch: %s/%s\n\n" "$remote" "$default_branch"
+
+echo "## Local branches (excluding $default_branch)"
+git for-each-ref refs/heads --format='%(refname:short)|%(committerdate:short)|%(authorname)|%(subject)' \
+  | grep -v "^${default_branch}|" \
+  | sort || true
+
+echo
+echo "## Remote branches already merged into $remote/$default_branch"
+git branch -r --merged "$remote/$default_branch" \
+  | sed 's/^..//' \
+  | grep "^$remote/" \
+  | grep -vE "^$remote/(${default_branch}|HEAD)$" \
+  | sort || true
+
+echo
+echo "## Remote branches NOT merged into $remote/$default_branch"
+git branch -r --no-merged "$remote/$default_branch" \
+  | sed 's/^..//' \
+  | grep "^$remote/" \
+  | grep -vE "^$remote/(${default_branch}|HEAD)$" \
+  | sort || true

--- a/scripts/git/branch-hygiene.sh
+++ b/scripts/git/branch-hygiene.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="dry-run"
+REMOTE="origin"
+DEFAULT_BRANCH="main"
+PROTECT_REGEX='^(main|master|dev|develop|staging|release/.*)$'
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--apply] [--remote origin] [--default-branch main] [--protect-regex '<regex>']
+
+Deletes ONLY remote feature/* branches that are already merged into <remote>/<default-branch>.
+Default mode is dry-run.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) MODE="apply"; shift ;;
+    --remote) REMOTE="${2:-}"; shift 2 ;;
+    --default-branch) DEFAULT_BRANCH="${2:-}"; shift 2 ;;
+    --protect-regex) PROTECT_REGEX="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$REMOTE" || -z "$DEFAULT_BRANCH" ]]; then
+  echo "remote and default branch are required" >&2
+  exit 1
+fi
+
+git fetch "$REMOTE" --prune >/dev/null
+
+mapfile -t MERGED_REMOTE_BRANCHES < <(
+  git branch -r --merged "$REMOTE/$DEFAULT_BRANCH" \
+    | sed 's/^..//' \
+    | grep "^$REMOTE/feature/" \
+    | sed "s#^$REMOTE/##" \
+    | sort -u || true
+)
+
+if [[ ${#MERGED_REMOTE_BRANCHES[@]} -eq 0 ]]; then
+  echo "No merged remote feature branches found."
+  exit 0
+fi
+
+echo "Mode: $MODE"
+echo "Remote: $REMOTE"
+echo "Base: $REMOTE/$DEFAULT_BRANCH"
+echo
+
+echo "Merged candidate branches:"
+printf ' - %s\n' "${MERGED_REMOTE_BRANCHES[@]}"
+echo
+
+DELETED=0
+for BRANCH in "${MERGED_REMOTE_BRANCHES[@]}"; do
+  if [[ "$BRANCH" =~ $PROTECT_REGEX ]]; then
+    echo "SKIP protected: $BRANCH"
+    continue
+  fi
+
+  if [[ "$MODE" == "dry-run" ]]; then
+    echo "DRY-RUN delete: $REMOTE/$BRANCH"
+  else
+    echo "Deleting: $REMOTE/$BRANCH"
+    git push "$REMOTE" --delete "$BRANCH"
+    DELETED=$((DELETED + 1))
+  fi
+done
+
+if [[ "$MODE" == "apply" ]]; then
+  echo
+  echo "Deleted $DELETED remote branches."
+else
+  echo
+  echo "Dry-run complete. Re-run with --apply to delete merged branches."
+fi


### PR DESCRIPTION
## Summary
- add `scripts/git/branch-hygiene-audit.sh` to inventory local/remote merged and unmerged branches
- add generated audit snapshot at `docs/branch-hygiene-2026-04-08.md`
- add `docs/branch-hygiene-policy.md` with safe cleanup workflow

## Why
Issue #42 requested branch hygiene cleanup support. This PR provides decomposition-first Slice A (inventory + policy) before any destructive cleanup.

## Validation
- Ran `./scripts/git/branch-hygiene-audit.sh main origin`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a branch hygiene policy with protection rules, a weekly audit cadence, dry‑run-first cleanup guidance, and audit/reporting procedures.
  * Added dated audit and operations reports summarizing local and remote branch statuses and cleanup actions.

* **Chores**
  * Added maintenance scripts to produce branch inventories and to safely identify/delete merged feature branches (dry‑run by default; explicit apply required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->