### PR TITLE
fix: remove pytest from ingestor runtime requirements

### DIFF
--- a/apps/ingestor/requirements.txt
+++ b/apps/ingestor/requirements.txt
@@ -5,4 +5,3 @@ pydantic-settings>=2.1.0
 python-dotenv>=1.0.0
 structlog>=24.1.0
 tenacity>=8.2.0
-pytest==8.3.5


### PR DESCRIPTION
## Summary
- remove dev-only `pytest` from the ingestor runtime requirements
- keep test tooling out of the production dependency audit baseline
- stop `pip-audit` from flagging a non-runtime package as a production risk

## Validation
- `SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=ci-placeholder-key pytest apps/ingestor/tests -q`
- `pip-audit --strict -r apps/ingestor/requirements.txt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies for maintenance purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->