### PR TITLE
chore: gitignore Claude Code local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 # hand-maintained apps/web/src/types/database.ts remains the source of truth)
 apps/web/src/types/database.generated.ts
 
+# Claude Code local state (machine-specific). A shared .claude/settings.json,
+# if ever added, stays trackable.
+.claude/settings.local.json
+.claude/worktrees/
+
 # Dependencies
 node_modules/
 .pnp


### PR DESCRIPTION
Stops `.claude/settings.local.json` and `.claude/worktrees/` (machine-specific Claude Code state) from showing up as untracked noise in `git status`. A shared `.claude/settings.json`, if ever added, remains trackable.

Docs/config-only change — no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration files for local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->