### PR TITLE
feat: add AeroAPI planning guardrails

### DIFF
--- a/apps/ingestor/src/aeroapi_guardrails.py
+++ b/apps/ingestor/src/aeroapi_guardrails.py
@@ -1,0 +1,92 @@
+"""Helpers for sizing FlightAware AeroAPI polling and frontend egress safely."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+MONTH_SECONDS = 30 * 24 * 60 * 60
+BYTES_PER_GIB = 1024**3
+SUPABASE_FREE_EGRESS_GIB = 5.0
+DEFAULT_AEROAPI_RESULT_LIMIT = 15
+
+
+@dataclass(frozen=True)
+class BoundingBox:
+    """Simple lat/lon bounding box for AeroAPI region searches."""
+
+    min_lat: float
+    min_lon: float
+    max_lat: float
+    max_lon: float
+
+
+def parse_bounding_box(raw: str) -> BoundingBox:
+    """Parse a `min_lat,min_lon,max_lat,max_lon` string into floats."""
+    parts = [part.strip() for part in raw.split(",")]
+    if len(parts) != 4:
+        raise ValueError("AEROAPI_BBOX must have 4 comma-separated numbers")
+
+    try:
+        min_lat, min_lon, max_lat, max_lon = (float(part) for part in parts)
+    except ValueError as exc:  # pragma: no cover - exercised via tests
+        raise ValueError("AEROAPI_BBOX values must be numeric") from exc
+
+    if not -90 <= min_lat <= 90 or not -90 <= max_lat <= 90:
+        raise ValueError("AEROAPI_BBOX latitude values must be between -90 and 90")
+    if not -180 <= min_lon <= 180 or not -180 <= max_lon <= 180:
+        raise ValueError("AEROAPI_BBOX longitude values must be between -180 and 180")
+    if min_lat >= max_lat:
+        raise ValueError("AEROAPI_BBOX min_lat must be less than max_lat")
+    if min_lon >= max_lon:
+        raise ValueError("AEROAPI_BBOX min_lon must be less than max_lon")
+
+    return BoundingBox(min_lat=min_lat, min_lon=min_lon, max_lat=max_lat, max_lon=max_lon)
+
+
+def estimate_monthly_search_requests(
+    poll_interval_seconds: int,
+    pages_per_poll: int,
+) -> int:
+    """Estimate how many AeroAPI search requests a given poll plan spends monthly."""
+    if poll_interval_seconds <= 0:
+        raise ValueError("poll_interval_seconds must be > 0")
+    if pages_per_poll <= 0:
+        raise ValueError("pages_per_poll must be > 0")
+
+    polls_per_month = MONTH_SECONDS / poll_interval_seconds
+    return int(round(polls_per_month * pages_per_poll))
+
+
+def estimate_monthly_result_rows(
+    poll_interval_seconds: int,
+    pages_per_poll: int,
+    results_per_page: int = DEFAULT_AEROAPI_RESULT_LIMIT,
+) -> int:
+    """Estimate the maximum monthly flight rows retrieved from AeroAPI."""
+    if results_per_page <= 0:
+        raise ValueError("results_per_page must be > 0")
+
+    monthly_requests = estimate_monthly_search_requests(poll_interval_seconds, pages_per_poll)
+    return monthly_requests * results_per_page
+
+
+def estimate_monthly_snapshot_egress_gib(
+    snapshot_size_kib: float,
+    refresh_interval_seconds: int,
+) -> float:
+    """Estimate monthly Supabase egress for one cached snapshot refresh cadence."""
+    if snapshot_size_kib <= 0:
+        raise ValueError("snapshot_size_kib must be > 0")
+    if refresh_interval_seconds <= 0:
+        raise ValueError("refresh_interval_seconds must be > 0")
+
+    refreshes_per_month = MONTH_SECONDS / refresh_interval_seconds
+    monthly_bytes = refreshes_per_month * snapshot_size_kib * 1024
+    return round(monthly_bytes / BYTES_PER_GIB, 3)
+
+
+def estimate_supabase_daily_egress_budget_mib(limit_gib: float = SUPABASE_FREE_EGRESS_GIB) -> float:
+    """Turn a monthly GiB ceiling into a simple daily MiB budget."""
+    if limit_gib <= 0:
+        raise ValueError("limit_gib must be > 0")
+    return round((limit_gib * 1024) / 30, 1)

--- a/apps/ingestor/src/config.py
+++ b/apps/ingestor/src/config.py
@@ -2,6 +2,14 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings
 
+from src.aeroapi_guardrails import (
+    estimate_monthly_result_rows,
+    estimate_monthly_search_requests,
+    estimate_monthly_snapshot_egress_gib,
+    estimate_supabase_daily_egress_budget_mib,
+    parse_bounding_box,
+)
+
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 VALID_FLIGHT_PROVIDERS = {"aviationstack", "example", "adsb1090"}
@@ -25,6 +33,13 @@ class Settings(BaseSettings):
     adsb_max_range_km: float = 200.0  # drop aircraft farther than this from MIA
     adsb_min_move_meters: float = 150.0  # skip writes for aircraft that barely moved
     adsb_max_seen_seconds: float = 60.0  # drop stale tracks (no recent position)
+
+    # AeroAPI planning defaults for South Florida region searches.
+    aeroapi_bbox: str = "25.2,-82.0,27.0,-80.0"
+    aeroapi_search_limit: int = 15
+    aeroapi_max_pages_per_poll: int = 4
+    aeroapi_snapshot_size_kib: float = 35.0
+    aeroapi_snapshot_refresh_seconds: int = 60
 
     # Ingestion
     poll_interval_seconds: int = 10800  # cost-control default: every 3 hours
@@ -63,10 +78,31 @@ settings = Settings()  # type: ignore[call-arg]
 
 def get_runtime_config_summary() -> dict[str, object]:
     """Return a sanitized runtime config payload for startup logging."""
+    aeroapi_plan = {
+        "bbox": settings.aeroapi_bbox,
+        "search_limit": settings.aeroapi_search_limit,
+        "max_pages_per_poll": settings.aeroapi_max_pages_per_poll,
+        "estimated_monthly_requests": estimate_monthly_search_requests(
+            settings.poll_interval_seconds,
+            settings.aeroapi_max_pages_per_poll,
+        ),
+        "estimated_monthly_result_rows": estimate_monthly_result_rows(
+            settings.poll_interval_seconds,
+            settings.aeroapi_max_pages_per_poll,
+            settings.aeroapi_search_limit,
+        ),
+        "estimated_snapshot_egress_gib": estimate_monthly_snapshot_egress_gib(
+            settings.aeroapi_snapshot_size_kib,
+            settings.aeroapi_snapshot_refresh_seconds,
+        ),
+        "daily_egress_budget_mib": estimate_supabase_daily_egress_budget_mib(),
+    }
+
     return {
         "flight_provider": settings.flight_provider,
         "flight_api_base_url": settings.flight_api_base_url,
         "flight_api_key_configured": bool(settings.flight_api_key),
+        "aeroapi_plan": aeroapi_plan,
         "airport": {
             "iata": settings.mia_iata_code,
             "icao": settings.mia_icao_code,
@@ -114,6 +150,23 @@ def validate_runtime_settings() -> None:
             errors.append("adsb_json_url is required when flight_provider=adsb1090")
         if settings.adsb_max_range_km <= 0:
             errors.append("adsb_max_range_km must be > 0 when flight_provider=adsb1090")
+
+    try:
+        parse_bounding_box(settings.aeroapi_bbox)
+    except ValueError as exc:
+        errors.append(str(exc))
+
+    if settings.aeroapi_search_limit <= 0 or settings.aeroapi_search_limit > 15:
+        errors.append("aeroapi_search_limit must be between 1 and 15")
+
+    if settings.aeroapi_max_pages_per_poll <= 0:
+        errors.append("aeroapi_max_pages_per_poll must be > 0")
+
+    if settings.aeroapi_snapshot_size_kib <= 0:
+        errors.append("aeroapi_snapshot_size_kib must be > 0")
+
+    if settings.aeroapi_snapshot_refresh_seconds <= 0:
+        errors.append("aeroapi_snapshot_refresh_seconds must be > 0")
 
     if errors:
         joined = "; ".join(errors)

--- a/apps/ingestor/tests/test_config_and_client.py
+++ b/apps/ingestor/tests/test_config_and_client.py
@@ -2,6 +2,13 @@
 
 import pytest
 from src import config, main
+from src.aeroapi_guardrails import (
+    estimate_monthly_result_rows,
+    estimate_monthly_search_requests,
+    estimate_monthly_snapshot_egress_gib,
+    estimate_supabase_daily_egress_budget_mib,
+    parse_bounding_box,
+)
 from src.providers.adsb1090_provider import Adsb1090Provider
 from src.providers.example_provider import ExampleProvider
 from src.services.supabase_client import SupabaseFlightClient
@@ -23,6 +30,20 @@ def test_validate_adsb_requires_positive_range(monkeypatch):
 def test_validate_passes_for_example_provider(monkeypatch):
     monkeypatch.setattr(config.settings, "flight_provider", "example")
     config.validate_runtime_settings()  # must not raise
+
+
+def test_validate_rejects_bad_aeroapi_bbox(monkeypatch):
+    monkeypatch.setattr(config.settings, "flight_provider", "example")
+    monkeypatch.setattr(config.settings, "aeroapi_bbox", "25.2,-82.0,25.2,-80.0")
+    with pytest.raises(ValueError, match="min_lat"):
+        config.validate_runtime_settings()
+
+
+def test_validate_rejects_aeroapi_limit_above_api_cap(monkeypatch):
+    monkeypatch.setattr(config.settings, "flight_provider", "example")
+    monkeypatch.setattr(config.settings, "aeroapi_search_limit", 16)
+    with pytest.raises(ValueError, match="aeroapi_search_limit"):
+        config.validate_runtime_settings()
 
 
 def test_get_provider_returns_configured_instance(monkeypatch):
@@ -69,3 +90,16 @@ def test_upsert_flights_batches_in_chunks_of_50():
 def test_upsert_flights_empty_is_noop():
     client = SupabaseFlightClient.__new__(SupabaseFlightClient)
     assert client.upsert_flights([]) == 0
+
+
+def test_parse_bounding_box_and_request_estimates():
+    bbox = parse_bounding_box("25.2,-82.0,27.0,-80.0")
+    assert bbox.min_lat == 25.2
+    assert bbox.max_lon == -80.0
+    assert estimate_monthly_search_requests(900, 4) == 11520
+    assert estimate_monthly_result_rows(900, 4, 15) == 172800
+
+
+def test_snapshot_egress_estimates_match_cost_guardrail_defaults():
+    assert estimate_monthly_snapshot_egress_gib(35, 60) == pytest.approx(1.442, rel=0.001)
+    assert estimate_supabase_daily_egress_budget_mib() == pytest.approx(170.7, rel=0.001)

--- a/docs/cost-guardrails.md
+++ b/docs/cost-guardrails.md
@@ -98,6 +98,18 @@ client (`useFlights`) polls the route every 10 s — those hits land on the CDN,
 | 60 s | ~1.5 GB | ✅ recommended default (safest) |
 | ≤10 s | >9 GB | ❌ over budget |
 
+For the planned FlightAware AeroAPI migration (`TrackFlights#77`), the ingestor now mirrors these
+assumptions in code with `apps/ingestor/src/aeroapi_guardrails.py` and config defaults:
+
+- `AEROAPI_BBOX=25.2,-82.0,27.0,-80.0` for the first South Florida region
+- `AEROAPI_SEARCH_LIMIT=15` and `AEROAPI_MAX_PAGES_PER_POLL=4` to cap per-cycle request fan-out
+- `AEROAPI_SNAPSHOT_SIZE_KIB=35` and `AEROAPI_SNAPSHOT_REFRESH_SECONDS=60` to model the cached web
+  read path against the 5 GiB/month Supabase free-tier ceiling
+
+Those values are still adjustable, but the runtime config summary now emits the projected monthly
+request count, result-row count, and snapshot egress so operator changes are visible before a live
+provider rollout.
+
 **Guardrails:** keep **realtime OFF** (the 2M-msg/mo cap + per-client fan-out blow up with
 broadcasts). Keep `flights_current` an UPSERT (bounded rows) and `flights_history` off/downsampled
 to stay under 500 MB. If egress alerts fire, **raise** `SNAPSHOT_REFRESH_SECONDS` first.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -56,6 +56,7 @@ class BaseFlightProvider(ABC):
 | Provider | Module | API Key Required | Notes |
 |----------|--------|-----------------|-------|
 | AviationStack | `aviationstack_provider.py` | Yes | Production provider |
+| AeroAPI (planning scaffold) | config + `aeroapi_guardrails.py` | Yes | South Florida bbox/cost sizing scaffold for issue `#77` before wiring a live provider |
 | Example | `example_provider.py` | No | Generates mock data for development |
 
 Set `FLIGHT_PROVIDER=example` in `.env` to use mock data without an API key.
@@ -97,5 +98,23 @@ Use `journalctl -u mia-ingestor -f` on the Raspberry Pi to monitor.
 | `FLIGHT_API_KEY` | (required for aviationstack) | API key |
 | `FLIGHT_API_BASE_URL` | `https://api.aviationstack.com/v1` | API base URL |
 | `POLL_INTERVAL_SECONDS` | `60` | Seconds between poll cycles |
+| `AEROAPI_BBOX` | `25.2,-82.0,27.0,-80.0` | South Florida search box (`min_lat,min_lon,max_lat,max_lon`) |
+| `AEROAPI_SEARCH_LIMIT` | `15` | Planned per-page cap; matches AeroAPI Standard page-size ceiling |
+| `AEROAPI_MAX_PAGES_PER_POLL` | `4` | Safety cap for a single poll cycle when region results span multiple pages |
+| `AEROAPI_SNAPSHOT_SIZE_KIB` | `35` | Used for monthly Supabase egress estimation |
+| `AEROAPI_SNAPSHOT_REFRESH_SECONDS` | `60` | Planned server-side snapshot cadence for cached reads |
 | `SUPABASE_URL` | (required) | Supabase project URL |
 | `SUPABASE_SERVICE_ROLE_KEY` | (required) | Service role key (bypasses RLS) |
+
+## AeroAPI planning guardrails
+
+Issue `#77` needs two budgets protected before the live FlightAware provider is enabled:
+
+- **AeroAPI request volume:** the ingestor now computes estimated monthly requests/result rows from
+  `POLL_INTERVAL_SECONDS`, `AEROAPI_MAX_PAGES_PER_POLL`, and `AEROAPI_SEARCH_LIMIT`.
+- **Supabase egress:** the same runtime summary estimates uncached monthly snapshot egress from
+  `AEROAPI_SNAPSHOT_SIZE_KIB` and `AEROAPI_SNAPSHOT_REFRESH_SECONDS` so the public map can stay
+  inside the free-tier read budget.
+
+This scaffold is intentionally planning-only for now: it validates the bbox/env contract and emits
+cost-safe startup numbers before a live AeroAPI fetcher is wired into the ingestor loop.


### PR DESCRIPTION
## Summary
- add reusable AeroAPI bounding-box and budget guardrail helpers for TrackFlights issue #77
- wire South Florida bbox, page-limit, and snapshot-egress planning defaults into ingestor config + runtime summary validation
- add regression coverage plus pipeline/cost docs so the later live FlightAware provider can be wired on top of explicit request and egress assumptions

## Validation
- `SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=test /home/rmendy/.openclaw/workspace/codespace/TrackFlights/apps/ingestor/.venv/bin/python -m pytest apps/ingestor/tests/test_config_and_client.py -q -p no:cacheprovider`
- `npm run build`
- `node /home/rmendy/.openclaw/workspace/codespace/TrackFlights/node_modules/typescript/bin/tsc --noEmit --project apps/web/tsconfig.json` *(blocked by `/tmp` `ENOSPC` after the worktree npm install partially corrupted transient `node_modules`; no app code was changed to chase that environment issue)*

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AeroAPI planning guardrails for validating geographic bounds and estimating request volume, result counts, and data-transfer usage.
  * Added configurable AeroAPI settings with safe defaults and startup summaries showing projected usage and egress.
  * Added fail-fast validation for invalid AeroAPI configuration values.

* **Documentation**
  * Documented AeroAPI planning assumptions, configuration options, cost estimates, and its planning-only status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->