### PR TITLE
feat: cached dashboard summary route + dual-ingestor deploy infra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,9 +38,12 @@ WEATHER_RETENTION_DAYS=3
 ANOMALIES_RETENTION_DAYS=7
 
 # Web snapshot route: how often the server re-reads Supabase (edge-cached for all
-# viewers). Drives Supabase egress — see docs/cost-guardrails.md. 30-60s recommended.
-SNAPSHOT_REFRESH_SECONDS=30
+# viewers). Drives Supabase egress — see docs/cost-guardrails.md.
+SNAPSHOT_REFRESH_SECONDS=120
 SUPABASE_SNAPSHOT_PAYLOAD_KB=35
+# Dashboard summary route (weather + analytics + predictions + anomalies in
+# one CDN-cached response). 300s keeps dashboard egress negligible.
+DASHBOARD_SUMMARY_REFRESH_SECONDS=300
 
 # Optional planning inputs for `npm run ops:supabase-free-tier`
 SUPABASE_EXPECTED_DB_SIZE_MB=120

--- a/apps/web/src/app/api/dashboard/summary/route.test.ts
+++ b/apps/web/src/app/api/dashboard/summary/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { queryMock } = vi.hoisted(() => ({ queryMock: vi.fn() }));
+
+// A permissive chainable stub: every builder method returns the chain, and the
+// chain resolves (thenable) with the next queued result. The route runs six
+// queries via Promise.all.
+vi.mock("@/lib/supabase", () => {
+  const chain = () => {
+    const c: Record<string, unknown> = {};
+    for (const m of ["select", "order", "limit", "eq", "gte", "lte"]) {
+      c[m] = () => c;
+    }
+    c.then = (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+      Promise.resolve(queryMock()).then(resolve, reject);
+    return c;
+  };
+  return { supabase: { from: () => chain() } };
+});
+
+import { GET } from "./route";
+
+describe("GET /api/dashboard/summary", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it("bundles all dashboard reads behind one edge-cached response", async () => {
+    queryMock.mockReturnValue({ data: [], error: null });
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toContain("s-maxage=");
+    const body = await res.json();
+    expect(body).toMatchObject({
+      analyticsHourly: [],
+      analyticsDaily: [],
+      weatherCurrent: null,
+      weatherForecast: [],
+      predictions: [],
+      anomalies: [],
+    });
+    expect(queryMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("surfaces the latest weather row as weatherCurrent", async () => {
+    queryMock.mockReturnValue({ data: [{ id: "w1", temperature_c: 31 }], error: null });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.weatherCurrent).toEqual({ id: "w1", temperature_c: 31 });
+  });
+
+  it("returns 503 + no-store when any Supabase read errors", async () => {
+    queryMock
+      .mockReturnValueOnce({ data: [], error: null })
+      .mockReturnValue({ data: null, error: { message: "boom" } });
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = await res.json();
+    expect(body.error).toBe("boom");
+  });
+});

--- a/apps/web/src/app/api/dashboard/summary/route.ts
+++ b/apps/web/src/app/api/dashboard/summary/route.ts
@@ -11,7 +11,9 @@ import {
 // analytics, predictions, anomalies). Browsers hit this route instead of
 // Supabase directly, so dashboard egress is bounded by the refresh window
 // rather than the audience size — same pattern as /api/flights/snapshot.
-const REFRESH_SECONDS = Number(process.env.DASHBOARD_SUMMARY_REFRESH_SECONDS ?? 300);
+const parsedRefreshSeconds = Number(process.env.DASHBOARD_SUMMARY_REFRESH_SECONDS);
+const REFRESH_SECONDS =
+  Number.isFinite(parsedRefreshSeconds) && parsedRefreshSeconds > 0 ? parsedRefreshSeconds : 300;
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/src/app/api/dashboard/summary/route.ts
+++ b/apps/web/src/app/api/dashboard/summary/route.ts
@@ -1,0 +1,90 @@
+import { supabase } from "@/lib/supabase";
+import {
+  ANALYTICS_DAILY_COLUMNS,
+  ANALYTICS_HOURLY_COLUMNS,
+  ANOMALY_COLUMNS,
+  PREDICTION_COLUMNS,
+  WEATHER_COLUMNS,
+} from "@/lib/dashboard-selects";
+
+// One CDN-cached response bundles every non-flight dashboard read (weather,
+// analytics, predictions, anomalies). Browsers hit this route instead of
+// Supabase directly, so dashboard egress is bounded by the refresh window
+// rather than the audience size — same pattern as /api/flights/snapshot.
+const REFRESH_SECONDS = Number(process.env.DASHBOARD_SUMMARY_REFRESH_SECONDS ?? 300);
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const nowIso = new Date().toISOString();
+  const anomalyCutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const [hourly, daily, weatherCurrent, weatherForecast, predictions, anomalies] =
+    await Promise.all([
+      supabase
+        .from("analytics_hourly")
+        .select(ANALYTICS_HOURLY_COLUMNS)
+        .order("hour", { ascending: false })
+        .limit(48),
+      supabase
+        .from("analytics_daily")
+        .select(ANALYTICS_DAILY_COLUMNS)
+        .order("date", { ascending: false })
+        .limit(30),
+      supabase
+        .from("weather_snapshots")
+        .select(WEATHER_COLUMNS)
+        .eq("airport_iata", "MIA")
+        .lte("observed_at", nowIso)
+        .order("observed_at", { ascending: false })
+        .limit(1),
+      supabase
+        .from("weather_snapshots")
+        .select(WEATHER_COLUMNS)
+        .eq("airport_iata", "MIA")
+        .gte("observed_at", nowIso)
+        .order("observed_at", { ascending: true })
+        .limit(12),
+      supabase
+        .from("delay_predictions")
+        .select(PREDICTION_COLUMNS)
+        .gte("expires_at", nowIso)
+        .order("predicted_value", { ascending: false })
+        .limit(500),
+      supabase
+        .from("traffic_anomalies")
+        .select(ANOMALY_COLUMNS)
+        .gte("detected_at", anomalyCutoff)
+        .order("detected_at", { ascending: false })
+        .limit(200),
+    ]);
+
+  const firstError = [hourly, daily, weatherCurrent, weatherForecast, predictions, anomalies].find(
+    (res) => res.error
+  )?.error;
+
+  if (firstError) {
+    return Response.json(
+      { error: firstError.message },
+      { status: 503, headers: { "Cache-Control": "no-store" } }
+    );
+  }
+
+  return Response.json(
+    {
+      analyticsHourly: hourly.data ?? [],
+      analyticsDaily: daily.data ?? [],
+      weatherCurrent: weatherCurrent.data?.[0] ?? null,
+      weatherForecast: weatherForecast.data ?? [],
+      predictions: predictions.data ?? [],
+      anomalies: anomalies.data ?? [],
+      lastUpdate: Date.now(),
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": `public, s-maxage=${REFRESH_SECONDS}, stale-while-revalidate=${REFRESH_SECONDS * 2}`,
+      },
+    }
+  );
+}

--- a/apps/web/src/app/api/flights/snapshot/route.ts
+++ b/apps/web/src/app/api/flights/snapshot/route.ts
@@ -5,7 +5,9 @@ import { FLIGHT_SNAPSHOT_COLUMNS } from "@/lib/dashboard-selects";
 // re-runs the function (and the Supabase read) about once per window, so
 // Supabase egress is independent of how many browsers are watching. See
 // docs/cost-guardrails.md for the free-tier egress budget.
-const REFRESH_SECONDS = Number(process.env.SNAPSHOT_REFRESH_SECONDS ?? 30);
+const parsedRefreshSeconds = Number(process.env.SNAPSHOT_REFRESH_SECONDS);
+const REFRESH_SECONDS =
+  Number.isFinite(parsedRefreshSeconds) && parsedRefreshSeconds > 0 ? parsedRefreshSeconds : 30;
 
 export const dynamic = "force-dynamic";
 

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
-import { ANALYTICS_DAILY_COLUMNS, ANALYTICS_HOURLY_COLUMNS } from "@/lib/dashboard-selects";
+import { fetchDashboardSummary } from "@/lib/dashboard-summary";
 import type { AnalyticsDaily, AnalyticsHourly } from "@/types/database";
+
+const POLL_MS = 5 * 60 * 1000;
 
 export function useAnalytics() {
   const [hourly, setHourly] = useState<AnalyticsHourly[]>([]);
@@ -11,26 +12,30 @@ export function useAnalytics() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function fetch() {
-      const [hourlyRes, dailyRes] = await Promise.all([
-        supabase
-          .from("analytics_hourly")
-          .select(ANALYTICS_HOURLY_COLUMNS)
-          .order("hour", { ascending: false })
-          .limit(48),
-        supabase
-          .from("analytics_daily")
-          .select(ANALYTICS_DAILY_COLUMNS)
-          .order("date", { ascending: false })
-          .limit(30),
-      ]);
+    let cancelled = false;
 
-      if (hourlyRes.data) setHourly(hourlyRes.data as AnalyticsHourly[]);
-      if (dailyRes.data) setDaily(dailyRes.data as AnalyticsDaily[]);
-      setLoading(false);
+    async function load() {
+      try {
+        const summary = await fetchDashboardSummary();
+        if (cancelled) return;
+        setHourly(summary.analyticsHourly);
+        setDaily(summary.analyticsDaily);
+      } catch {
+        // Keep last known data; the next poll retries.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
 
-    fetch();
+    load();
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, POLL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, []);
 
   return { hourly, daily, loading };

--- a/apps/web/src/hooks/useAnomalies.ts
+++ b/apps/web/src/hooks/useAnomalies.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import { fetchDashboardSummary } from "@/lib/dashboard-summary";
 import type { TrafficAnomaly } from "@/types/database";
 
-const ANOMALY_COLUMNS =
-  "id,anomaly_type,severity,title,description,metric_name,metric_value,baseline_value,deviation_pct,affected_flights,affected_airlines,affected_count,is_active,detected_at,resolved_at,detection_model";
+const POLL_MS = 5 * 60 * 1000;
 
 interface UseAnomaliesReturn {
   anomalies: TrafficAnomaly[];
@@ -14,41 +13,36 @@ interface UseAnomaliesReturn {
   loading: boolean;
 }
 
+// Anomalies previously kept a Supabase realtime channel open per viewer; like
+// the flights realtime subscription (removed for egress cost), they now ride
+// the shared CDN-cached summary poll.
 export function useAnomalies(): UseAnomaliesReturn {
   const [anomalies, setAnomalies] = useState<TrafficAnomaly[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function fetch() {
-      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    let cancelled = false;
 
-      const { data } = await supabase
-        .from("traffic_anomalies")
-        .select(ANOMALY_COLUMNS)
-        .gte("detected_at", cutoff)
-        .order("detected_at", { ascending: false })
-        .limit(200);
-
-      if (data) setAnomalies(data as TrafficAnomaly[]);
-      setLoading(false);
+    async function load() {
+      try {
+        const summary = await fetchDashboardSummary();
+        if (cancelled) return;
+        setAnomalies(summary.anomalies);
+      } catch {
+        // Keep last known data; the next poll retries.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
 
-    fetch();
-
-    const channel = supabase
-      .channel("anomalies_realtime")
-      .on(
-        "postgres_changes",
-        { event: "INSERT", schema: "public", table: "traffic_anomalies" },
-        (payload) => {
-          const newAnomaly = payload.new as TrafficAnomaly;
-          setAnomalies((prev) => [newAnomaly, ...prev].slice(0, 200));
-        }
-      )
-      .subscribe();
+    load();
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, POLL_MS);
 
     return () => {
-      supabase.removeChannel(channel);
+      cancelled = true;
+      clearInterval(interval);
     };
   }, []);
 

--- a/apps/web/src/hooks/usePredictions.ts
+++ b/apps/web/src/hooks/usePredictions.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
-import { PREDICTION_COLUMNS } from "@/lib/dashboard-selects";
+import { fetchDashboardSummary } from "@/lib/dashboard-summary";
 import type { DelayPrediction } from "@/types/database";
+
+const POLL_MS = 5 * 60 * 1000;
 
 interface UsePredictionsReturn {
   predictions: DelayPrediction[];
@@ -16,23 +17,29 @@ export function usePredictions(): UsePredictionsReturn {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function fetch() {
-      const now = new Date().toISOString();
+    let cancelled = false;
 
-      const { data } = await supabase
-        .from("delay_predictions")
-        .select(PREDICTION_COLUMNS)
-        .gte("expires_at", now)
-        .order("predicted_value", { ascending: false })
-        .limit(500);
-
-      if (data) setPredictions(data as DelayPrediction[]);
-      setLoading(false);
+    async function load() {
+      try {
+        const summary = await fetchDashboardSummary();
+        if (cancelled) return;
+        setPredictions(summary.predictions);
+      } catch {
+        // Keep last known data; the next poll retries.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
 
-    fetch();
-    const interval = setInterval(fetch, 2 * 60 * 60 * 1000);
-    return () => clearInterval(interval);
+    load();
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, POLL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, []);
 
   const highRiskFlights = predictions.filter(

--- a/apps/web/src/hooks/useWeather.ts
+++ b/apps/web/src/hooks/useWeather.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
-import { WEATHER_COLUMNS } from "@/lib/dashboard-selects";
+import { fetchDashboardSummary } from "@/lib/dashboard-summary";
 import type { WeatherSnapshot } from "@/types/database";
+
+const POLL_MS = 5 * 60 * 1000;
 
 interface UseWeatherReturn {
   current: WeatherSnapshot | null;
@@ -17,32 +18,30 @@ export function useWeather(): UseWeatherReturn {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    async function fetch() {
-      const { data: latest } = await supabase
-        .from("weather_snapshots")
-        .select(WEATHER_COLUMNS)
-        .eq("airport_iata", "MIA")
-        .order("observed_at", { ascending: false })
-        .limit(1);
+    let cancelled = false;
 
-      if (latest && latest.length > 0) setCurrent(latest[0] as WeatherSnapshot);
-
-      const now = new Date().toISOString();
-      const { data: forecastData } = await supabase
-        .from("weather_snapshots")
-        .select(WEATHER_COLUMNS)
-        .eq("airport_iata", "MIA")
-        .gte("observed_at", now)
-        .order("observed_at", { ascending: true })
-        .limit(12);
-
-      if (forecastData) setForecast(forecastData as WeatherSnapshot[]);
-      setLoading(false);
+    async function load() {
+      try {
+        const summary = await fetchDashboardSummary();
+        if (cancelled) return;
+        setCurrent(summary.weatherCurrent);
+        setForecast(summary.weatherForecast);
+      } catch {
+        // Keep last known data; the next poll retries.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     }
 
-    fetch();
-    const interval = setInterval(fetch, 2 * 60 * 60 * 1000);
-    return () => clearInterval(interval);
+    load();
+    const interval = setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, POLL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, []);
 
   return { current, forecast, loading };

--- a/apps/web/src/lib/dashboard-selects.ts
+++ b/apps/web/src/lib/dashboard-selects.ts
@@ -87,6 +87,25 @@ export const WEATHER_COLUMNS = [
   "data_source",
 ].join(",");
 
+export const ANOMALY_COLUMNS = [
+  "id",
+  "anomaly_type",
+  "severity",
+  "title",
+  "description",
+  "metric_name",
+  "metric_value",
+  "baseline_value",
+  "deviation_pct",
+  "affected_flights",
+  "affected_airlines",
+  "affected_count",
+  "is_active",
+  "detected_at",
+  "resolved_at",
+  "detection_model",
+].join(",");
+
 export const PREDICTION_COLUMNS = [
   "id",
   "flight_iata",

--- a/apps/web/src/lib/dashboard-summary.ts
+++ b/apps/web/src/lib/dashboard-summary.ts
@@ -1,0 +1,57 @@
+// Shared client for /api/dashboard/summary. Four dashboard hooks consume the
+// same payload, so requests are deduplicated module-wide: one fetch serves
+// every hook mounted within the freshness window.
+import type {
+  AnalyticsDaily,
+  AnalyticsHourly,
+  DelayPrediction,
+  TrafficAnomaly,
+  WeatherSnapshot,
+} from "@/types/database";
+
+export interface DashboardSummary {
+  analyticsHourly: AnalyticsHourly[];
+  analyticsDaily: AnalyticsDaily[];
+  weatherCurrent: WeatherSnapshot | null;
+  weatherForecast: WeatherSnapshot[];
+  predictions: DelayPrediction[];
+  anomalies: TrafficAnomaly[];
+  lastUpdate: number;
+}
+
+// Client-side freshness window. The CDN already caches the route response;
+// this only prevents simultaneous hooks from firing duplicate requests.
+const CLIENT_TTL_MS = 60_000;
+
+let cached: { at: number; data: DashboardSummary } | null = null;
+let inflight: Promise<DashboardSummary> | null = null;
+
+export async function fetchDashboardSummary(force = false): Promise<DashboardSummary> {
+  if (!force && cached && Date.now() - cached.at < CLIENT_TTL_MS) {
+    return cached.data;
+  }
+  if (inflight) {
+    return inflight;
+  }
+
+  inflight = (async () => {
+    try {
+      const resp = await fetch("/api/dashboard/summary");
+      if (!resp.ok) {
+        throw new Error(`dashboard summary fetch failed: ${resp.status}`);
+      }
+      const data = (await resp.json()) as DashboardSummary;
+      cached = { at: Date.now(), data };
+      return data;
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+export function resetDashboardSummaryCache(): void {
+  cached = null;
+  inflight = null;
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,6 +7,8 @@
 3. Set environment variables:
    - `NEXT_PUBLIC_SUPABASE_URL`
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `SNAPSHOT_REFRESH_SECONDS=120` (map snapshot CDN window)
+   - `DASHBOARD_SUMMARY_REFRESH_SECONDS=300` (dashboard summary CDN window)
 4. Deploy — Vercel auto-builds on push to `main`
 
 ## Database (Supabase)
@@ -19,34 +21,70 @@
    ```
 3. Enable Realtime on `flights_current` table
 4. Copy the project URL and anon key to your `.env` files
+5. Verify the analytics rollup cron jobs exist (added by
+   `20260710120000_analytics_rollups.sql`):
+   ```sql
+   select jobname, schedule from cron.job;
+   ```
+   If pg_cron could not be enabled on the project, the four rollup functions
+   still exist and can be invoked via RPC from the ingestor instead.
 
-## Ingestor (Raspberry Pi)
+> **Free-tier note:** paused projects (1 week of inactivity) stop resolving
+> DNS entirely — the web app shows 503s from `/api/*` routes and the ingestor
+> logs connection errors. Restore the project from the Supabase dashboard.
 
-### Option A: systemd (recommended)
+## Ingestor (Raspberry Pi) — two services
+
+Production runs two ingestor processes against the shared `flights_current`
+table:
+
+| Unit | Provider | Interval | Owns |
+|---|---|---|---|
+| `mia-ingestor-adsb` | `adsb1090` (local PiAware/dump1090) | 15 s | live positions, weather |
+| `mia-ingestor-aeroapi` | `flightaware` (AeroAPI boards) | 4 h | schedules, delays, cancellations, gates, predictions |
+
+Setup:
 
 ```bash
-# On the Raspberry Pi
-sudo cp infra/systemd/mia-ingestor.service /etc/systemd/system/
+# On the Raspberry Pi, from the repo root
+cp infra/systemd/env.adsb.example .env.adsb        # set ADSB_JSON_URL to your feeder
+cp infra/systemd/env.aeroapi.example .env.aeroapi  # budget/cadence overrides
+# Put the AeroAPI key in the shared .env as FLIGHT_API_KEY.
+# Remove FLIGHT_PROVIDER / POLL_INTERVAL_SECONDS from the shared .env —
+# the per-unit env files own those now.
+
+sudo cp infra/systemd/mia-ingestor-adsb.service /etc/systemd/system/
+sudo cp infra/systemd/mia-ingestor-aeroapi.service /etc/systemd/system/
+# Edit both unit files if your checkout path/user differ from the template.
 sudo systemctl daemon-reload
-sudo systemctl enable mia-ingestor
-sudo systemctl start mia-ingestor
+sudo systemctl disable --now mia-ingestor        # retire the single-provider unit
+sudo systemctl enable --now mia-ingestor-adsb mia-ingestor-aeroapi
 
 # Check status
-sudo systemctl status mia-ingestor
-journalctl -u mia-ingestor -f
+journalctl -u mia-ingestor-adsb -f
+journalctl -u mia-ingestor-aeroapi -f
 ```
 
 ### Option B: Docker
 
 ```bash
-docker build -t mia-ingestor -f infra/docker/Dockerfile.ingestor .
-docker run -d --name mia-ingestor --env-file .env mia-ingestor
+docker compose -f infra/compose/docker-compose.yml up -d ingestor-adsb ingestor-aeroapi
 ```
+
+## AeroAPI cost calibration (first 48h)
+
+The budget guard assumes `AEROAPI_COST_PER_QUERY_USD=0.02`. After the first
+day of polling, compare `aeroapi_queries_mtd` from the ingestor logs against
+the FlightAware portal's usage page and correct the env var. The guard halts
+polling at `AEROAPI_MONTHLY_BUDGET_USD` regardless, so a wrong assumption
+costs coverage, never money.
 
 ## Monitoring
 
-- **Ingestor logs**: `journalctl -u mia-ingestor -f`
-- **Supabase dashboard**: Monitor database usage and realtime connections
+- **Ingestor logs**: `journalctl -u mia-ingestor-adsb -f` / `journalctl -u mia-ingestor-aeroapi -f`
+  - AeroAPI spend: look for `aeroapi_spend_mtd_usd` / `aeroapi_projected_month_usd`
+- **Supabase dashboard**: egress + DB size weekly (free tier: 5 GB/mo egress, 500 MB DB)
+- **Preflight**: `npm run ops:supabase-free-tier` before each release
 - **Vercel dashboard**: Monitor frontend deployments and analytics
 
 ## Security Hardening (Phase 4)

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3.8"
 # Docker Compose for local development.
 # Supabase is expected to be external (cloud or local CLI).
 # Set environment variables in ../.env or pass via shell.
+#
+# Production runs two ingestor processes (one provider each) — mirrored here.
+# Start only what you need, e.g.: docker compose up web ingestor-adsb
 
 services:
   web:
@@ -14,17 +17,37 @@ services:
     environment:
       - NEXT_PUBLIC_SUPABASE_URL=${NEXT_PUBLIC_SUPABASE_URL}
       - NEXT_PUBLIC_SUPABASE_ANON_KEY=${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      - SNAPSHOT_REFRESH_SECONDS=${SNAPSHOT_REFRESH_SECONDS:-120}
+      - DASHBOARD_SUMMARY_REFRESH_SECONDS=${DASHBOARD_SUMMARY_REFRESH_SECONDS:-300}
     restart: unless-stopped
 
-  ingestor:
+  ingestor-adsb:
     build:
       context: ../..
       dockerfile: infra/docker/Dockerfile.ingestor
     environment:
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - FLIGHT_PROVIDER=adsb1090
+      - ADSB_JSON_URL=${ADSB_JSON_URL:-http://host.docker.internal:8080/data/aircraft.json}
+      - POLL_INTERVAL_SECONDS=${ADSB_POLL_INTERVAL_SECONDS:-15}
+      - WEATHER_ENABLED=true
+    restart: unless-stopped
+
+  ingestor-aeroapi:
+    build:
+      context: ../..
+      dockerfile: infra/docker/Dockerfile.ingestor
+    environment:
+      - SUPABASE_URL=${SUPABASE_URL}
+      - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+      - FLIGHT_PROVIDER=flightaware
       - FLIGHT_API_KEY=${FLIGHT_API_KEY}
-      - FLIGHT_API_BASE_URL=${FLIGHT_API_BASE_URL:-https://api.aviationstack.com/v1}
-      - FLIGHT_PROVIDER=${FLIGHT_PROVIDER:-aviationstack}
-      - POLL_INTERVAL_SECONDS=${POLL_INTERVAL_SECONDS:-60}
+      - FLIGHT_API_BASE_URL=https://aeroapi.flightaware.com/aeroapi
+      - POLL_INTERVAL_SECONDS=${AEROAPI_POLL_INTERVAL_SECONDS:-14400}
+      - AEROAPI_MONTHLY_BUDGET_USD=${AEROAPI_MONTHLY_BUDGET_USD:-9.0}
+      - AEROAPI_COST_PER_QUERY_USD=${AEROAPI_COST_PER_QUERY_USD:-0.02}
+      - AEROAPI_MAX_PAGES=${AEROAPI_MAX_PAGES:-1}
+      - WEATHER_ENABLED=false
+      - PREDICTIONS_ENABLED=true
     restart: unless-stopped

--- a/infra/systemd/env.adsb.example
+++ b/infra/systemd/env.adsb.example
@@ -1,0 +1,10 @@
+# Per-unit overrides for mia-ingestor-adsb.service — copy to <repo>/.env.adsb
+# Loaded AFTER the shared .env, so values here win.
+FLIGHT_PROVIDER=adsb1090
+POLL_INTERVAL_SECONDS=15
+# Point at the PiAware/dump1090 host if it is a different machine.
+ADSB_JSON_URL=http://127.0.0.1:8080/data/aircraft.json
+# This unit owns weather ingestion; the AeroAPI unit reads it from the DB.
+WEATHER_ENABLED=true
+PREDICTIONS_ENABLED=false
+ANOMALY_DETECTION_ENABLED=false

--- a/infra/systemd/env.aeroapi.example
+++ b/infra/systemd/env.aeroapi.example
@@ -1,0 +1,16 @@
+# Per-unit overrides for mia-ingestor-aeroapi.service — copy to <repo>/.env.aeroapi
+# Loaded AFTER the shared .env, so values here win.
+FLIGHT_PROVIDER=flightaware
+FLIGHT_API_BASE_URL=https://aeroapi.flightaware.com/aeroapi
+# Boards every 4 hours + scheduled boards once/day ≈ 14 queries/day ≈ $8.52/mo
+# at the assumed $0.02/query. The budget guard halts polling at the cap.
+POLL_INTERVAL_SECONDS=14400
+AEROAPI_MONTHLY_BUDGET_USD=9.0
+AEROAPI_COST_PER_QUERY_USD=0.02
+AEROAPI_MAX_PAGES=1
+# Weather is owned by the ADS-B unit; this unit reads the latest snapshot
+# from the DB for predictions.
+WEATHER_ENABLED=false
+PREDICTIONS_ENABLED=true
+# Enable after ~1 week of analytics_hourly baseline.
+ANOMALY_DETECTION_ENABLED=false

--- a/infra/systemd/mia-ingestor-adsb.service
+++ b/infra/systemd/mia-ingestor-adsb.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=MIA Flight Tracker - ADS-B Position Ingestor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/mia-flight-tracker/apps/ingestor
+# Later EnvironmentFile entries override earlier ones — per-unit differences
+# (provider, poll interval) live in .env.adsb, shared secrets in .env.
+EnvironmentFile=/home/pi/mia-flight-tracker/.env
+EnvironmentFile=/home/pi/mia-flight-tracker/.env.adsb
+ExecStart=/home/pi/mia-flight-tracker/apps/ingestor/venv/bin/python -m src.main
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Resource limits
+MemoryMax=256M
+CPUQuota=50%
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/mia-ingestor-aeroapi.service
+++ b/infra/systemd/mia-ingestor-aeroapi.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=MIA Flight Tracker - FlightAware AeroAPI Schedule Ingestor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/mia-flight-tracker/apps/ingestor
+# Later EnvironmentFile entries override earlier ones — per-unit differences
+# (provider, poll interval, budget) live in .env.aeroapi, shared secrets in .env.
+EnvironmentFile=/home/pi/mia-flight-tracker/.env
+EnvironmentFile=/home/pi/mia-flight-tracker/.env.aeroapi
+ExecStart=/home/pi/mia-flight-tracker/apps/ingestor/venv/bin/python -m src.main
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Resource limits
+MemoryMax=256M
+CPUQuota=50%
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Closes the last egress hole for #78 and adds the production deploy scaffolding for #77:

- **`/api/dashboard/summary`**: one CDN-cached response (`s-maxage=300, swr=600`) bundling weather, hourly/daily analytics, active predictions, and anomalies. The four dashboard hooks previously queried Supabase **directly from each viewer's browser** — egress scaled with audience size. They now poll this route via a module-level deduped fetcher (one request serves all four hooks; 5-min poll, paused when the tab is hidden). The anomalies realtime channel is removed.
- Projected total egress with `SNAPSHOT_REFRESH_SECONDS=120`: ~0.8–1.3 GB/mo realistic, ≈2.3 GB/mo worst case — ≥2× headroom under the 5 GB free tier.
- **Deploy infra**: `mia-ingestor-adsb.service` (positions+weather, 15s) and `mia-ingestor-aeroapi.service` (schedules+predictions, 4h) with per-unit `.env.adsb`/`.env.aeroapi` overrides (systemd: later `EnvironmentFile=` wins), compose mirror, and a deployment-guide rewrite (incl. AeroAPI cost recalibration steps and the Supabase free-tier pause gotcha).

## Test plan
- [x] `npm test` — 18 passed (new `route.test.ts`: bundling, weatherCurrent extraction, 503+no-store on any read error)
- [x] `tsc --noEmit`, ESLint clean
- [ ] Post-deploy: response headers show `s-maxage=300`; Supabase egress flat under page hammering (blocked: project paused)

Vercel env to set on merge: `SNAPSHOT_REFRESH_SECONDS=120`, `DASHBOARD_SUMMARY_REFRESH_SECONDS=300`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consolidated dashboard summary endpoint for analytics, weather, predictions, and anomalies.
  - Dashboard data now refreshes automatically every five minutes while the page is visible.
  - Added response caching and last-known-data fallback for improved resilience.
  - Added separate ADS-B and AeroAPI ingestion services with independent configuration.

- **Documentation**
  - Updated deployment, monitoring, cost-control, and environment configuration guidance.

- **Tests**
  - Added coverage for successful dashboard responses, weather selection, caching headers, and service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->