### PR TITLE
fix: weather_snapshots column drift crashes ingestor poll loop

### DIFF
--- a/apps/ingestor/src/services/weather_ingester.py
+++ b/apps/ingestor/src/services/weather_ingester.py
@@ -12,7 +12,15 @@ logger = structlog.get_logger()
 
 MIA_LAT = 25.7959
 MIA_LON = -80.2870
-WEATHER_COLUMNS = "airport_iata,observed_at,temperature_c,dewpoint_c,humidity_pct,pressure_hpa,wind_speed_knots,wind_gust_knots,wind_direction_deg,visibility_km,cloud_cover_pct,weather_code,weather_description,is_thunderstorm,is_fog,precipitation_mm"
+# Must match supabase/migrations/00002 (weather_snapshots) — an unknown column
+# makes PostgREST 400 the read and kills every poll cycle after the first
+# weather interval elapses.
+WEATHER_COLUMNS = (
+    "airport_iata,observed_at,temperature_c,feels_like_c,humidity_pct,pressure_hpa,"
+    "wind_speed_knots,wind_gust_knots,wind_direction_deg,visibility_km,"
+    "cloud_coverage_pct,weather_code,weather_description,is_thunderstorm,is_fog,"
+    "is_freezing,precipitation_mm,precipitation_probability"
+)
 
 
 class WeatherIngester:

--- a/apps/ingestor/tests/test_config_and_client.py
+++ b/apps/ingestor/tests/test_config_and_client.py
@@ -116,8 +116,16 @@ def test_weather_ingester_columns_match_schema():
     migration = Path(__file__).resolve().parents[3] / (
         "supabase/migrations/00002_weather_predictions_anomalies.sql"
     )
+    import re
+
     schema_sql = migration.read_text()
-    table_ddl = schema_sql.split("CREATE TABLE weather_snapshots")[1].split(");")[0]
+    match = re.search(
+        r"CREATE TABLE (?:IF NOT EXISTS )?(?:\w+\.)?\"?weather_snapshots\"?\s*\((.*?)\n\);",
+        schema_sql,
+        re.DOTALL,
+    )
+    assert match, "weather_snapshots DDL not found in migration 00002"
+    table_ddl = match.group(1)
 
     missing = [col for col in WEATHER_COLUMNS.split(",") if col not in table_ddl]
     assert not missing, f"columns not in weather_snapshots schema: {missing}"

--- a/apps/ingestor/tests/test_config_and_client.py
+++ b/apps/ingestor/tests/test_config_and_client.py
@@ -105,3 +105,19 @@ def test_parse_bounding_box_and_request_estimates():
 def test_snapshot_egress_estimates_match_cost_guardrail_defaults():
     assert estimate_monthly_snapshot_egress_gib(35, 60) == pytest.approx(1.442, rel=0.001)
     assert estimate_supabase_daily_egress_budget_mib() == pytest.approx(170.7, rel=0.001)
+
+
+def test_weather_ingester_columns_match_schema():
+    """Every projected weather column must exist in migration 00002."""
+    from pathlib import Path
+
+    from src.services.weather_ingester import WEATHER_COLUMNS
+
+    migration = Path(__file__).resolve().parents[3] / (
+        "supabase/migrations/00002_weather_predictions_anomalies.sql"
+    )
+    schema_sql = migration.read_text()
+    table_ddl = schema_sql.split("CREATE TABLE weather_snapshots")[1].split(");")[0]
+
+    missing = [col for col in WEATHER_COLUMNS.split(",") if col not in table_ddl]
+    assert not missing, f"columns not in weather_snapshots schema: {missing}"

--- a/apps/ingestor/tests/test_flightaware_provider.py
+++ b/apps/ingestor/tests/test_flightaware_provider.py
@@ -191,6 +191,13 @@ def test_scheduled_boards_fetch_once_per_day(tmp_path, monkeypatch):
 
 
 def test_watermark_windows_advance(tmp_path, monkeypatch):
+    from src import config
+
+    # Pin the lookback: the assertion below assumes the poll interval exceeds
+    # the 15-minute watermark overlap (true at the production 4h cadence, but
+    # not necessarily for whatever .env this test machine has).
+    monkeypatch.setattr(config.settings, "poll_interval_seconds", 14400)
+
     provider = _bare_provider()
     provider.base_url = "https://aeroapi.example/aeroapi"
     provider.api_key = "k"


### PR DESCRIPTION
## Summary
Production incident found during rollout: the ingestor crash-loops with `column weather_snapshots.dewpoint_c does not exist` once the first weather interval elapses. `weather_ingester.py`'s hardcoded `WEATHER_COLUMNS` had the same schema drift class as the dashboard selects fixed in #79 (`dewpoint_c` → doesn't exist; `cloud_cover_pct` → `cloud_coverage_pct`). The first cycle works (writes don't use the projection); `get_latest()` then 400s and aborts every subsequent cycle.

- Aligns the projection with migration 00002 (adds `feels_like_c`, `is_freezing`, `precipitation_probability` that the schema has)
- New regression test: every projected column must appear in the migration DDL
- Pins `poll_interval_seconds` in the watermark test (it implicitly assumed lookback > the 15-min overlap and failed under the Pi's real .env)

## Test plan
- [x] `pytest apps/ingestor/tests` — 49 passed
- [x] ruff + black clean
- [ ] Post-merge on the Pi: poll cycles keep completing past the weather interval (I'll verify during rollout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated weather snapshot data selection to match the current schema, including corrected cloud coverage and expanded weather details.
  * Improved reliability of polling-window behavior across different test environment settings.

* **Tests**
  * Added validation to detect mismatches between selected weather fields and the database schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->